### PR TITLE
exit supply cheaper

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -264,7 +264,7 @@ contract VaultV2 is ERC20, IVaultV2 {
     function claimExit(uint256 shares, address receiver, address supplier) external returns (uint256 claimedAssets) {
         if (msg.sender != supplier) _spendAllowance(supplier, msg.sender, shares);
         totalExitSupply -= shares;
-        uint256 exitShares = shares.mulDiv(WAD - exitFee, WAD,Math.Rounding.Floor);
+        uint256 exitShares = shares.mulDiv(WAD - exitFee, WAD, Math.Rounding.Floor);
         address supplierExitAccount = exitAccount(supplier);
         _burn(supplierExitAccount, exitShares);
         _update(supplierExitAccount, exitFeeRecipient, shares - exitShares);


### PR DESCRIPTION
Alternative to the exit method used in https://github.com/morpho-org/vaults-v2/pull/39. Reduces the cost of reading `totalSupply` (1 slot vs. 2 slots).

The exit fee must be taken at claim time (not request time), otherwise users could just send shares to their exit accounts and then exit for free.