### PR TITLE
refactor: irm interface

### DIFF
--- a/src/IRM.sol
+++ b/src/IRM.sol
@@ -19,7 +19,7 @@ contract IRM is IIRM {
         _interestPerSecond = newInterestPerSecond;
     }
 
-    function interestPerSecond(uint256) external view returns (uint256) {
+    function interestPerSecond(uint256, uint256) external view returns (uint256) {
         return _interestPerSecond;
     }
 }

--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -237,7 +237,7 @@ contract VaultV2 is ERC20, IVaultV2 {
 
     function accruedFeeShares() public view returns (uint256, uint256, uint256, uint256) {
         uint256 elapsed = block.timestamp - lastUpdate;
-        uint256 interest = IIRM(irm).interestPerSecond(elapsed) * elapsed;
+        uint256 interest = IIRM(irm).interestPerSecond(totalAssets, elapsed) * elapsed;
         uint256 newTotalAssets = totalAssets + interest;
 
         uint256 protocolFee = IVaultV2Factory(factory).protocolFee();

--- a/src/interfaces/IIRM.sol
+++ b/src/interfaces/IIRM.sol
@@ -2,5 +2,5 @@
 pragma solidity >=0.5.0;
 
 interface IIRM {
-    function interestPerSecond(uint256 elapsed) external view returns (uint256);
+    function interestPerSecond(uint256 totalAssets, uint256 elapsed) external view returns (uint256);
 }


### PR DESCRIPTION
fix #40 

this helps metamorpho style IRMs

```solidity
function interestPerSecond(uint256 elapsed, uint256 totalAssets) {
    uint256 newTotalAssets = // fetch on markets.
    interest = newTotalAssets - totalAssets;
    return interest / elapsed;
}
```