### PR TITLE
Remove duplicated zeroFloorSub

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -11,11 +11,11 @@ import {ProtocolFee, IVaultV2Factory} from "./interfaces/IVaultV2Factory.sol";
 
 import {ErrorsLib} from "./libraries/ErrorsLib.sol";
 import {WAD} from "./libraries/ConstantsLib.sol";
-import {MathLib} from "./libraries/MathLib.sol";
+import {UtilsLib} from "./libraries/UtilsLib.sol";
 
 contract VaultV2 is ERC20, IVaultV2 {
     using Math for uint256;
-    using MathLib for uint256;
+    using UtilsLib for uint256;
 
     /* CONSTANT */
     uint64 public constant TIMELOCK_CAP = 2 weeks;

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.28;
-
-library MathLib {
-    function zeroFloorSub(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? a - b : 0;
-    }
-}


### PR DESCRIPTION
This PR remove duplicate zeroFloorSub by removing MathLib in favor of UtilsLibs.