### PR TITLE
add permissioned token callback for bundler

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,8 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+ignored_error_codes = ["transient-storage"]
+ignored_warnings_from = ["test"]
 via_ir = true
 optimizer_runs = 999999 # Etherscan does not support verifying contracts with more optimization runs.
 evm_version = "cancun"

--- a/src/interfaces/IGate.sol
+++ b/src/interfaces/IGate.sol
@@ -4,4 +4,5 @@ pragma solidity >=0.5.0;
 interface IGate {
     function canUseShares(address account) external view returns (bool);
     function canReceiveAssets(address account) external view returns (bool);
+    function canHandleSharesOnBehalf(address account) external view returns (bool);
 }

--- a/src/interfaces/IPermissionedTokenHandler.sol
+++ b/src/interfaces/IPermissionedTokenHandler.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface IPermissionedTokenHandler {
+    function permissionedTokenHandlerCallback(address onBehalf, uint256 amount, bytes calldata callback) external;
+}

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -9,6 +9,9 @@ interface IAdapter {
 }
 
 interface IVaultV2 is IERC20 {
+    // ERC-X (Permissioned token with callback)
+    function handleOnBehalf(address onBehalf, uint256 amount, bytes calldata callback) external;
+
     // ERC-2612 (Permit)
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
         external;

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -35,4 +35,5 @@ library ErrorsLib {
     error LiquidityAdapterInvariantBroken();
     error ApproveReverted();
     error ApproveReturnedFalse();
+    error AlreadyHandling();
 }

--- a/src/libraries/SharesHandlerLib.sol
+++ b/src/libraries/SharesHandlerLib.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+library SharesHandlerLib {
+    bytes32 constant HANDLER_PREFIX = keccak256("Morpho VaultV2 Shares Handler");
+
+    function setHandled(address handler, address owner) external {
+        bytes32 handlerKey = keccak256(abi.encodePacked(HANDLER_PREFIX, handler));
+        assembly {
+            tstore(handlerKey, owner)
+        }
+    }
+
+    function getHandled(address handler) external view returns (address handled) {
+        bytes32 handlerKey = keccak256(abi.encodePacked(HANDLER_PREFIX, handler));
+        assembly {
+            handled := tload(handlerKey)
+        }
+    }
+}


### PR DESCRIPTION
Builds on top of https://github.com/morpho-org/vaults-v2/pull/122.

Based on [this idea](https://www.notion.so/Permissioned-tokens-that-work-well-with-the-bundler-1d4d69939e6d80bea43ac3c58bbb21ed?pvs=4#1ded69939e6d8097a006dae18b1cc42d), gives compatibility with a future adapter for permissioned tokens.