### PR TITLE
Remove liquidity adapter check

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -410,7 +410,7 @@ contract VaultV2 is IVaultV2 {
 
     function exit(uint256 assets, uint256 shares, address receiver, address onBehalf) internal {
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));
-        if (assets > idleAssets && liquidityAdapter != address(0)) {
+        if (assets > idleAssets) {
             this.reallocateToIdle(liquidityAdapter, liquidityData, assets - idleAssets);
         }
         uint256 _allowance = allowance[onBehalf][msg.sender];

--- a/test/ERC20Test.sol
+++ b/test/ERC20Test.sol
@@ -242,7 +242,7 @@ contract ERC20Test is BaseTest {
         burnAmount = _bound(burnAmount, mintAmount + 1, type(uint256).max);
 
         vault.mint(mintAmount, to);
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert();
         vault.redeem(burnAmount, to, to);
     }
 


### PR DESCRIPTION
Rationale:
- it reverts earlier
- it obfuscates why it's ok to not have a try-catch around `reallocateToIdle` (because it will revert later anyway)