### PR TITLE
remove lastUpdate initialization

### DIFF
--- a/certora/Invariants.spec
+++ b/certora/Invariants.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 methods {
     function multicall(bytes[]) external => NONDET DELETE;
 

--- a/certora/NotRevertingCalls.spec
+++ b/certora/NotRevertingCalls.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 methods {
     function liquidityData() external returns(bytes) envfree;
 }


### PR DESCRIPTION
Rationale: until a vic is set, interest accrual will always be 0. And interests are accrued (and lastUpdate is updated) when a vic is set.