### PR TITLE
Simple force deallocate

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -564,20 +564,16 @@ contract VaultV2 is IVaultV2 {
 
     /// @dev Returns shares withdrawn as penalty.
     /// @dev This function will automatically realize potential losses.
-    function forceDeallocate(address[] memory adapters, bytes[] memory data, uint256[] memory assets, address onBehalf)
+    function forceDeallocate(address adapter, bytes memory data, uint256 assets, address onBehalf)
         external
         returns (uint256)
     {
-        require(adapters.length == data.length && adapters.length == assets.length, ErrorsLib.InvalidInputLength());
-        uint256 penaltyAssets;
-        for (uint256 i; i < adapters.length; i++) {
-            this.deallocate(adapters[i], data[i], assets[i]);
-            penaltyAssets += assets[i].mulDivDown(forceDeallocatePenalty[adapters[i]], WAD);
-        }
+        this.deallocate(adapter, data, assets);
 
         // The penalty is taken as a withdrawal that is donated to the vault.
+        uint256 penaltyAssets = assets.mulDivDown(forceDeallocatePenalty[adapter], WAD);
         uint256 shares = withdraw(penaltyAssets, address(this), onBehalf);
-        emit EventsLib.ForceDeallocate(msg.sender, adapters, data, assets, onBehalf);
+        emit EventsLib.ForceDeallocate(msg.sender, adapter, data, assets, onBehalf);
         return shares;
     }
 

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -92,7 +92,7 @@ interface IVaultV2 is IERC20, IPermissionedToken {
     function revoke(bytes memory data) external;
 
     // Force reallocate to idle
-    function forceDeallocate(address[] memory adapters, bytes[] memory data, uint256[] memory assets, address onBehalf)
+    function forceDeallocate(address adapters, bytes memory data, uint256 assets, address onBehalf)
         external
         returns (uint256 withdrawnShares);
 

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -16,7 +16,6 @@ library ErrorsLib {
     error TimelockCapIsFixed();
     error TimelockDurationTooHigh();
     error CapExceeded();
-    error InvalidInputLength();
     error DataNotTimelocked();
     error DataAlreadyPending();
     error TimelockNotIncreasing();

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -77,7 +77,7 @@ library EventsLib {
     );
 
     event ForceDeallocate(
-        address indexed sender, address[] adapters, bytes[] data, uint256[] assets, address indexed onBehalf
+        address indexed sender, address adapter, bytes data, uint256 assets, address indexed onBehalf
     );
 
     event CreateVaultV2(address indexed owner, address indexed asset, address indexed vaultV2);

--- a/test/ForceDeallocateTest.sol
+++ b/test/ForceDeallocateTest.sol
@@ -27,24 +27,6 @@ contract ForceDeallocateTest is BaseTest {
         underlyingToken.approve(address(vault), type(uint256).max);
     }
 
-    function _list(address input) internal pure returns (address[] memory) {
-        address[] memory list = new address[](1);
-        list[0] = input;
-        return list;
-    }
-
-    function _list(bytes memory input) internal pure returns (bytes[] memory) {
-        bytes[] memory list = new bytes[](1);
-        list[0] = input;
-        return list;
-    }
-
-    function _list(uint256 input) internal pure returns (uint256[] memory) {
-        uint256[] memory list = new uint256[](1);
-        list[0] = input;
-        return list;
-    }
-
     function testForceDeallocate(uint256 supplied, uint256 deallocated, uint256 forceDeallocatePenalty) public {
         supplied = bound(supplied, 0, MAX_TEST_ASSETS);
         deallocated = bound(deallocated, 0, supplied);
@@ -68,27 +50,14 @@ contract ForceDeallocateTest is BaseTest {
 
         uint256 penaltyAssets = deallocated.mulDivDown(forceDeallocatePenalty, WAD);
         uint256 expectedShares = shares - vault.previewWithdraw(penaltyAssets);
-        address[] memory adapters = _list(address(adapter));
-        bytes[] memory data = _list(hex"");
-        uint256[] memory assets = _list(deallocated);
         vm.expectEmit();
-        emit EventsLib.ForceDeallocate(address(this), adapters, data, assets, address(this));
-        uint256 withdrawnShares = vault.forceDeallocate(adapters, data, assets, address(this));
+        emit EventsLib.ForceDeallocate(address(this), adapter, hex"", deallocated, address(this));
+        uint256 withdrawnShares = vault.forceDeallocate(adapter, hex"", deallocated, address(this));
         assertEq(shares - expectedShares, withdrawnShares);
         assertEq(underlyingToken.balanceOf(adapter), supplied - deallocated);
         assertEq(underlyingToken.balanceOf(address(vault)), deallocated);
         assertEq(vault.balanceOf(address(this)), expectedShares);
 
         vault.withdraw(min(deallocated, vault.previewRedeem(expectedShares)), address(this), address(this));
-    }
-
-    function testForceDeallocateInvalidInputLength(
-        address[] memory adapters,
-        bytes[] memory data,
-        uint256[] memory assets
-    ) public {
-        vm.assume(adapters.length != data.length || adapters.length != assets.length);
-        vm.expectRevert(ErrorsLib.InvalidInputLength.selector);
-        vault.forceDeallocate(adapters, data, assets, address(this));
     }
 }

--- a/test/RealizeLossTest.sol
+++ b/test/RealizeLossTest.sol
@@ -31,9 +31,6 @@ contract RealizeLossTest is BaseTest {
     bytes internal idData;
     bytes32 internal id;
     bytes32[] internal expectedIds;
-    bytes[] internal bytesArray;
-    uint256[] internal uint256Array;
-    address[] internal adapterArray;
 
     function setUp() public override {
         super.setUp();
@@ -52,15 +49,6 @@ contract RealizeLossTest is BaseTest {
         id = keccak256(idData);
         expectedIds[0] = id;
         adapter.setIds(expectedIds);
-
-        adapterArray = new address[](1);
-        adapterArray[0] = address(adapter);
-
-        bytesArray = new bytes[](1);
-        bytesArray[0] = hex"";
-
-        uint256Array = new uint256[](1);
-        uint256Array[0] = 0;
     }
 
     function testRealizeLossAllocate(uint256 deposit, uint256 expectedLoss) public {
@@ -114,7 +102,7 @@ contract RealizeLossTest is BaseTest {
 
         // Realize the loss.
         vm.prank(allocator);
-        vault.forceDeallocate(adapterArray, bytesArray, uint256Array, address(this));
+        vault.forceDeallocate(address(adapter), hex"", 0, address(this));
         assertEq(vault.totalAssets(), deposit - expectedLoss, "total assets should have decreased by the loss");
 
         if (expectedLoss > 0) {


### PR DESCRIPTION
The loop was introduced to make it easier to pass the relative caps check on exit, but this check no longer exists