### PR TITLE
Bound memory access

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -429,7 +429,7 @@ contract VaultV2 is IVaultV2 {
         (bool success, bytes memory data) =
             address(vic).staticcall(abi.encodeCall(IVic.interestPerSecond, (_totalAssets, elapsed)));
         uint256 output;
-        if (success) {
+        if (success && data.length >= 32) {
             assembly ("memory-safe") {
                 output := mload(add(data, 32))
             }


### PR DESCRIPTION
Linked to #328.
It could be one of the culprit why the verif is slow: because unallocated locations in memory are accessed.
Apart from fixing the verification, it seems like a good practice to only access allocated memory locations