### PR TITLE
chainsecurity 5.2/Spearbit-16: accrue on deallocate and add tests

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -353,6 +353,8 @@ contract VaultV2 is IVaultV2 {
         );
         require(isAdapter[adapter], ErrorsLib.NotAdapter());
 
+        accrueInterest();
+
         (bytes32[] memory ids, uint256 loss) = IAdapter(adapter).deallocate(data, assets);
 
         if (loss > 0) {

--- a/test/AccruingFunctionsTest.sol
+++ b/test/AccruingFunctionsTest.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "./BaseTest.sol";
+
+contract EmptyAdapter is IAdapter {
+    bytes32[] ids = [keccak256("id")];
+
+    function allocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
+        return (ids, 0);
+    }
+
+    function deallocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
+        return (ids, 0);
+    }
+}
+
+contract AccrueInterestTest is BaseTest {
+    EmptyAdapter adapter;
+
+    function setUp() public override {
+        super.setUp();
+
+        adapter = new EmptyAdapter();
+
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
+        vault.setIsAdapter(address(adapter), true);
+
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setVic, (address(vic))));
+        vault.setVic(address(vic));
+    }
+
+    function testAllocateAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vm.prank(allocator);
+        vault.allocate(address(adapter), hex"", 0);
+    }
+
+    function testDeallocateAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vm.prank(allocator);
+        vault.deallocate(address(adapter), hex"", 0);
+    }
+
+    function testDepositAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.deposit(0, address(this));
+    }
+
+    function testMintAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.mint(0, address(this));
+    }
+
+    function testWithdrawAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.withdraw(0, address(this), address(this));
+    }
+
+    function testRedeemAccruesInterest() public {
+        skip(1);
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.redeem(0, address(this), address(this));
+    }
+
+    function testSetVicAccruesInterest() public {
+        skip(1);
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setVic, (address(vic))));
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.setVic(address(vic));
+    }
+
+    function testSetPerformanceFeeAccruesInterest() public {
+        skip(1);
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setPerformanceFee, (0)));
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.setPerformanceFee(0);
+    }
+
+    function testSetManagementFeeAccruesInterest() public {
+        skip(1);
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setManagementFee, (0)));
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.setManagementFee(0);
+    }
+
+    function testSetPerformanceFeeRecipientAccruesInterest() public {
+        skip(1);
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setPerformanceFeeRecipient, (address(0))));
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.setPerformanceFeeRecipient(address(0));
+    }
+
+    function testSetManagementFeeRecipientAccruesInterest() public {
+        skip(1);
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.setManagementFeeRecipient, (address(0))));
+        vm.expectCall(address(vic), bytes.concat(IVic.interestPerSecond.selector));
+        vault.setManagementFeeRecipient(address(0));
+    }
+}


### PR DESCRIPTION
Addresses the following finding and add missing tests on functions that should call `accrueInterest`.

> 5.2 Fee Inconsistency When Realizing a Loss
> 
> The callpaths involving` allocate()` will take the management fee through `accrueInterest()` before realizing the loss (`allocate()`, `mint()`, `deposit()`). Some of the callpaths involving `deallocate()` also behave similarly (`redeem()`, `withdraw()`), but the other callpaths involving `deallocate()` will first realize the loss, and then eventually take the management fee. This means that for the same initial state, the management fee that is taken will depend on which action will be executed first.
> 
> Example:
> 
> `totalAssets = A loss = L interest = I`
> 
> Case 1 with `allocate()`:
> 1. `allocate()` is called
> 2. management fee is taken on `A + I`
> 3. loss is realized
> 
> Case 2 with `deallocate()`:
> 1. `deallocate()` is called
> 2. loss is realized
> 3. management fee is eventually taken on `A - L + I`


@QGarchery edit: related (and fixes) [Cantina 016 ](https://cantina.xyz/code/96198e58-f9fd-4295-9eae-f7b006eb3e02/findings?finding=16) as well