### PR TITLE
Interfaces small fixes

### DIFF
--- a/src/adapters/interfaces/IMetaMorphoAdapter.sol
+++ b/src/adapters/interfaces/IMetaMorphoAdapter.sol
@@ -14,7 +14,6 @@ interface IMetaMorphoAdapter is IAdapter {
     error NotAuthorized();
     error InvalidData();
     error CannotSkimMetaMorphoShares();
-    error CannotRealizeAsMuch();
     error WrongAsset();
 
     /* FUNCTIONS */

--- a/src/interfaces/IPermissionedToken.sol
+++ b/src/interfaces/IPermissionedToken.sol
@@ -2,6 +2,6 @@
 pragma solidity >=0.5.0;
 
 interface IPermissionedToken {
-    function canSend(address account) external returns (bool);
-    function canReceive(address account) external returns (bool);
+    function canSend(address account) external view returns (bool);
+    function canReceive(address account) external view returns (bool);
 }

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -97,8 +97,6 @@ interface IVaultV2 is IERC20, IPermissionedToken {
         returns (uint256 withdrawnShares);
 
     // Gate vault / permissioned token
-    function canSend(address account) external returns (bool);
-    function canReceive(address account) external returns (bool);
-    function canSendUnderlyingAssets(address account) external returns (bool);
-    function canReceiveUnderlyingAssets(address account) external returns (bool);
+    function canSendUnderlyingAssets(address account) external view returns (bool);
+    function canReceiveUnderlyingAssets(address account) external view returns (bool);
 }


### PR DESCRIPTION
Addresses some issues in [Cantina 002](https://cantina.xyz/code/96198e58-f9fd-4295-9eae-f7b006eb3e02/findings?finding=2), some of which are done in #315 but deciding to do it more scoped after [this comment](https://github.com/morpho-org/vault-v2/pull/315#discussion_r2115981487):
> [IVaultV2.sol#L100-L101](https://github.com/morpho-org/vault-v2/blob/77aa7c5baa823697ed7a35fa0df2fd0f3617be00/src/interfaces/IVaultV2.sol#L100-L101): canSend and canReceive are already declared in IPermissionedToken which is inherited by IVaultV2 and thus can be removed from IVaultV2 declaration.

> [IMetaMorphoAdapter.sol#L11](https://github.com/morpho-org/vault-v2/blob/77aa7c5baa823697ed7a35fa0df2fd0f3617be00/src/adapters/interfaces/IMetaMorphoAdapter.sol#L11): CannotRealizeAsMuch error is unused and can be removed

> [IVaultV2.sol#L100-L103](https://github.com/morpho-org/vault-v2/blob/77aa7c5baa823697ed7a35fa0df2fd0f3617be00/src/interfaces/IVaultV2.sol#L100-L103): canSend, canReceive, canSendUnderlyingAssets and canReceiveUnderlyingAssets must be defined as view functions.