### PR TITLE
Spearbit-25 (force deallocate amount)

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -584,7 +584,7 @@ contract VaultV2 is IVaultV2 {
     /// @dev The penalty is taken as a withdrawal for which assets are returned to the vault. In consequence,
     /// totalAssets is decreased normally along with totalSupply (the share price doesn't change except because of
     /// rounding errors), but the amount of assets actually controlled by the vault is not decreased.
-    /// @dev If a user has an A assets in the vault, and that the vault is already fully illiquid, the optimal amount to
+    /// @dev If a user has A assets in the vault, and that the vault is already fully illiquid, the optimal amount to
     /// force deallocate in order to exit the vault is min(liquidity_of_market, A / (1 + penalty)).
     /// This ensures that either the market is empty or that it leaves no shares nor liquidity after exiting.
     function forceDeallocate(address adapter, bytes memory data, uint256 assets, address onBehalf)


### PR DESCRIPTION
https://cantina.xyz/code/96198e58-f9fd-4295-9eae-f7b006eb3e02/findings/25

the optimal amount to force deallocate f is such that
a = f * p + w because you don’t want any assets left
f = w because you don’t want any liquidity left
so f = a / (1+p)