### PR TITLE
feat: sentinel can decrease only relative cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Multiple addresses can have this role.
 It can:
 
 - Deallocate funds from enabled markets to the “idle market”.
-- Decrease absolute caps.
 - Decrease relative caps.
 - Revoke timelocked actions.
 

--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -294,7 +294,7 @@ contract VaultV2 is IVaultV2 {
 
     function decreaseAbsoluteCap(bytes memory idData, uint256 newAbsoluteCap) external {
         bytes32 id = keccak256(idData);
-        require(msg.sender == curator || isSentinel[msg.sender], ErrorsLib.Unauthorized());
+        require(msg.sender == curator, ErrorsLib.Unauthorized());
         require(newAbsoluteCap <= caps[id].absoluteCap, ErrorsLib.AbsoluteCapNotDecreasing());
 
         // safe by invariant: config.absoluteCap fits on 128 bits

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -553,7 +553,7 @@ contract SettersTest is BaseTest {
     function testDecreaseAbsoluteCap(address rdm, bytes memory idData, uint256 oldAbsoluteCap, uint256 newAbsoluteCap)
         public
     {
-        vm.assume(rdm != curator && rdm != sentinel);
+        vm.assume(rdm != curator);
         vm.assume(newAbsoluteCap >= 0);
         vm.assume(idData.length > 0);
         newAbsoluteCap = bound(newAbsoluteCap, 0, type(uint128).max - 1);


### PR DESCRIPTION
fixes #285 

allows to keep the timelock of increaseAbsoluteCap long