### PR TITLE
skip accrue interest bug

### DIFF
--- a/test/AccrueInterestTest.sol
+++ b/test/AccrueInterestTest.sol
@@ -248,19 +248,19 @@ contract AccrueInterestTest is BaseTest {
         // If you pass just enough gas, interest does not accrue.
         // Everything is warm but it is on purpose, an attacker could warm them.
         skip(1);
-        vault.accrueInterest{gas: 390_000}();
+        vault.accrueInterest{gas: 350_000}();
         assertEq(vault.totalAssets(), 1 ether + 1);
     }
 }
 
 contract Reverting {}
 
-// consumes 390k gas and return 1
+// consumes ~350k gas and return 1
 contract ConsumesSomeGas {
     fallback() external {
         assembly {
             let i := 0
-            for {} lt(i, 9000) {} { i := add(i, 1) }
+            for {} lt(i, 8500) {} { i := add(i, 1) }
             mstore(0, 1)
             return(0, 32)
         }


### PR DESCRIPTION
the vic is called via a "try-catch" (not literally, but the behaviour is globally the same). With a vic that consumes enough gas (~350k), and if you pass the right amount of gas to the call, it is possible to make the vic revert but not accrueInterest, allowing to update `lastUpdate` without accruing any interest (when the vic reverts, the IPS is taken to be 0).

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/602a9497-4224-434a-819a-9447be2d66a4" />