### PR TITLE
account for rounding in adapters

### DIFF
--- a/src/adapters/MetaMorphoAdapter.sol
+++ b/src/adapters/MetaMorphoAdapter.sol
@@ -57,7 +57,7 @@ contract MetaMorphoAdapter is IMetaMorphoAdapter {
 
     /// @dev Does not log anything because the ids (logged in the parent vault) are enough.
     /// @dev Returns the ids of the allocation and the potential loss.
-    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         require(data.length == 0, InvalidData());
         require(msg.sender == parentVault, NotAuthorized());
 
@@ -74,12 +74,14 @@ contract MetaMorphoAdapter is IMetaMorphoAdapter {
 
         assetsInMetaMorpho = IERC4626(metaMorpho).previewRedeem(sharesInMetaMorpho);
 
-        return (ids(), interest);
+        uint256 gainedAssets = assetsInMetaMorpho - newAssetsInMetaMorpho;
+
+        return (ids(), interest, gainedAssets);
     }
 
     /// @dev Does not log anything because the ids (logged in the parent vault) are enough.
     /// @dev Returns the ids of the deallocation and the potential loss.
-    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         require(data.length == 0, InvalidData());
         require(msg.sender == parentVault, NotAuthorized());
 
@@ -96,7 +98,9 @@ contract MetaMorphoAdapter is IMetaMorphoAdapter {
 
         assetsInMetaMorpho = IERC4626(metaMorpho).previewRedeem(sharesInMetaMorpho);
 
-        return (ids(), interest);
+        uint256 lostAssets = newAssetsInMetaMorpho - assetsInMetaMorpho;
+
+        return (ids(), interest, lostAssets);
     }
 
     function realizeLoss(bytes memory data) external returns (bytes32[] memory, uint256) {

--- a/src/adapters/MorphoBlueAdapter.sol
+++ b/src/adapters/MorphoBlueAdapter.sol
@@ -74,7 +74,7 @@ contract MorphoBlueAdapter is IMorphoBlueAdapter {
 
     /// @dev Does not log anything because the ids (logged in the parent vault) are enough.
     /// @dev Returns the ids of the allocation and the potential loss.
-    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         MarketParams memory marketParams = abi.decode(data, (MarketParams));
         Id marketId = marketParams.id();
         require(msg.sender == parentVault, NotAuthorized());
@@ -95,12 +95,14 @@ contract MorphoBlueAdapter is IMorphoBlueAdapter {
         }
         position.assets = uint128(expectedSupplyAssets(marketParams, position.shares));
 
-        return (ids(marketParams), interest);
+        uint256 gainedAssets = position.assets - newAssetsInMarket;
+
+        return (ids(marketParams), interest, gainedAssets);
     }
 
     /// @dev Does not log anything because the ids (logged in the parent vault) are enough.
     /// @dev Returns the ids of the deallocation and the potential loss.
-    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         MarketParams memory marketParams = abi.decode(data, (MarketParams));
         Id marketId = marketParams.id();
         require(msg.sender == parentVault, NotAuthorized());
@@ -121,7 +123,9 @@ contract MorphoBlueAdapter is IMorphoBlueAdapter {
         }
         position.assets = uint128(expectedSupplyAssets(marketParams, position.shares));
 
-        return (ids(marketParams), interest);
+        uint256 lostAssets = newAssetsInMarket - position.assets;
+
+        return (ids(marketParams), interest, lostAssets);
     }
 
     function realizeLoss(bytes memory data) external returns (bytes32[] memory, uint256) {

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -3,11 +3,15 @@ pragma solidity >=0.5.0;
 
 /// @dev See VaultV2 Natspec for more details on adapter's spec.
 interface IAdapter {
-    /// @dev Returns the market' ids and the interest accrued on this market.
-    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory ids, uint256 interest);
+    /// @dev Returns the market' ids, the interest accrued on this market, and the actual assets gained by the adapter.
+    function allocate(bytes memory data, uint256 assets)
+        external
+        returns (bytes32[] memory ids, uint256 interest, uint256 gainedAssets);
 
-    /// @dev Returns the market' ids and the interest accrued on this market.
-    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory ids, uint256 interest);
+    /// @dev Returns the market' ids, the interest accrued on this market, and the actual assets lost by the adapter.
+    function deallocate(bytes memory data, uint256 assets)
+        external
+        returns (bytes32[] memory ids, uint256 interest, uint256 lostAssets);
 
     /// @dev Returns the market' ids and the loss occurred on this market.
     function realizeLoss(bytes memory data) external returns (bytes32[] memory ids, uint256 loss);

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -20,8 +20,22 @@ library EventsLib {
     event Constructor(address indexed owner, address indexed asset);
 
     // Allocation events
-    event Allocate(address indexed sender, address indexed adapter, uint256 assets, bytes32[] ids, uint256 interest);
-    event Deallocate(address indexed sender, address indexed adapter, uint256 assets, bytes32[] ids, uint256 interest);
+    event Allocate(
+        address indexed sender,
+        address indexed adapter,
+        uint256 assets,
+        bytes32[] ids,
+        uint256 interest,
+        uint256 gainedAssets
+    );
+    event Deallocate(
+        address indexed sender,
+        address indexed adapter,
+        uint256 assets,
+        bytes32[] ids,
+        uint256 interest,
+        uint256 lostAssets
+    );
     event ForceDeallocate(
         address indexed sender,
         address adapter,

--- a/test/AccruingFunctionsTest.sol
+++ b/test/AccruingFunctionsTest.sol
@@ -6,12 +6,12 @@ import "./BaseTest.sol";
 contract EmptyAdapter is IAdapter {
     bytes32[] ids = [keccak256("id")];
 
-    function allocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
-        return (ids, 0);
+    function allocate(bytes memory, uint256 assets) external view returns (bytes32[] memory, uint256, uint256) {
+        return (ids, 0, assets);
     }
 
-    function deallocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
-        return (ids, 0);
+    function deallocate(bytes memory, uint256 assets) external view returns (bytes32[] memory, uint256, uint256) {
+        return (ids, 0, assets);
     }
 
     function realizeLoss(bytes memory) external view returns (bytes32[] memory, uint256) {}

--- a/test/AllocateTest.sol
+++ b/test/AllocateTest.sol
@@ -88,7 +88,7 @@ contract AllocateTest is BaseTest {
         increaseRelativeCap("id-1", WAD);
         vm.prank(allocator);
         vm.expectEmit();
-        emit EventsLib.Allocate(allocator, mockAdapter, assets, ids, 0);
+        emit EventsLib.Allocate(allocator, mockAdapter, assets, ids, 0, assets);
         vault.allocate(mockAdapter, data, assets);
         assertEq(underlyingToken.balanceOf(address(vault)), 0, "Vault balance should be zero after allocation");
         assertEq(underlyingToken.balanceOf(mockAdapter), assets, "Adapter balance incorrect after allocation");
@@ -151,7 +151,7 @@ contract AllocateTest is BaseTest {
         // Normal path.
         vm.prank(allocator);
         vm.expectEmit();
-        emit EventsLib.Deallocate(allocator, mockAdapter, assetsOut, ids, 0);
+        emit EventsLib.Deallocate(allocator, mockAdapter, assetsOut, ids, 0, assetsOut);
         vault.deallocate(mockAdapter, data, assetsOut);
         assertEq(underlyingToken.balanceOf(address(vault)), assetsOut, "Vault balance incorrect after deallocation");
         assertEq(

--- a/test/ForceDeallocateTest.sol
+++ b/test/ForceDeallocateTest.sol
@@ -8,8 +8,20 @@ contract Adapter is IAdapter {
         IERC20(_underlyingToken).approve(_vault, type(uint256).max);
     }
 
-    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory ids, uint256 loss) {}
-    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory ids, uint256 loss) {}
+    function allocate(bytes memory data, uint256 assets)
+        external
+        returns (bytes32[] memory ids, uint256 loss, uint256)
+    {
+        return (ids, loss, assets);
+    }
+
+    function deallocate(bytes memory data, uint256 assets)
+        external
+        returns (bytes32[] memory ids, uint256 loss, uint256)
+    {
+        return (ids, loss, assets);
+    }
+
     function realizeLoss(bytes memory data) external returns (bytes32[] memory ids, uint256 loss) {}
 }
 

--- a/test/MetaMorphoAdapterTest.sol
+++ b/test/MetaMorphoAdapterTest.sol
@@ -71,7 +71,7 @@ contract MetaMorphoAdapterTest is Test {
         deal(address(asset), address(adapter), assets);
 
         vm.prank(address(parentVault));
-        (bytes32[] memory ids, uint256 interest) = adapter.allocate(hex"", assets);
+        (bytes32[] memory ids, uint256 interest, uint256 gainedAssets) = adapter.allocate(hex"", assets);
 
         assertEq(adapter.assetsInMetaMorpho(), assets, "incorrect assetsInMetaMorpho");
         uint256 adapterShares = metaMorpho.balanceOf(address(adapter));
@@ -95,7 +95,7 @@ contract MetaMorphoAdapterTest is Test {
         assertEq(beforeShares, initialAssets, "Precondition failed: shares not set");
 
         vm.prank(address(parentVault));
-        (bytes32[] memory ids, uint256 interest) = adapter.deallocate(hex"", withdrawAssets);
+        (bytes32[] memory ids, uint256 interest, uint256 lostAssets) = adapter.deallocate(hex"", withdrawAssets);
 
         assertEq(adapter.assetsInMetaMorpho(), initialAssets - withdrawAssets, "incorrect assetsInMetaMorpho");
         uint256 afterShares = metaMorpho.balanceOf(address(adapter));

--- a/test/MorphoBlueAdapterTest.sol
+++ b/test/MorphoBlueAdapterTest.sol
@@ -128,7 +128,8 @@ contract MorphoBlueAdapterTest is Test {
         deal(address(loanToken), address(adapter), assets);
 
         vm.prank(address(parentVault));
-        (bytes32[] memory ids, uint256 interest) = adapter.allocate(abi.encode(marketParams), assets);
+        (bytes32[] memory ids, uint256 interest, uint256 gainedAssets) =
+            adapter.allocate(abi.encode(marketParams), assets);
 
         assertEq(adapter.assetsInMarket(marketId), assets, "Incorrect assetsInMarket");
         assertEq(morpho.expectedSupplyAssets(marketParams, address(adapter)), assets, "Incorrect assets in Morpho");
@@ -149,7 +150,8 @@ contract MorphoBlueAdapterTest is Test {
         assertEq(beforeSupply, initialAssets, "Precondition failed: supply not set");
 
         vm.prank(address(parentVault));
-        (bytes32[] memory ids, uint256 interest) = adapter.deallocate(abi.encode(marketParams), withdrawAssets);
+        (bytes32[] memory ids, uint256 interest, uint256 lostAssets) =
+            adapter.deallocate(abi.encode(marketParams), withdrawAssets);
 
         assertEq(interest, 0, "Interest should be zero");
         assertEq(adapter.assetsInMarket(marketId), initialAssets - withdrawAssets, "Incorrect assetsInMarket");
@@ -248,12 +250,13 @@ contract MorphoBlueAdapterTest is Test {
         // Allocate reverts
         vm.prank(address(parentVault));
         if (expectedLoss > 0) vm.expectRevert(IMorphoBlueAdapter.RealizableLoss.selector);
-        (bytes32[] memory ids, uint256 interest) = adapter.allocate(abi.encode(marketParams), 0);
+        (bytes32[] memory ids, uint256 interest, uint256 gainedAssets) = adapter.allocate(abi.encode(marketParams), 0);
 
         // Deallocate reverts
         vm.prank(address(parentVault));
         if (expectedLoss > 0) vm.expectRevert(IMorphoBlueAdapter.RealizableLoss.selector);
-        (ids, interest) = adapter.deallocate(abi.encode(marketParams), 0);
+        uint256 lostAssets;
+        (ids, interest, lostAssets) = adapter.deallocate(abi.encode(marketParams), 0);
 
         // Realize loss
         uint256 snapshot = vm.snapshotState();

--- a/test/RealizeLossTest.sol
+++ b/test/RealizeLossTest.sol
@@ -17,12 +17,12 @@ contract MockAdapter is IAdapter {
         loss = _loss;
     }
 
-    function allocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
-        return (ids, 0);
+    function allocate(bytes memory, uint256 assets) external view returns (bytes32[] memory, uint256, uint256) {
+        return (ids, 0, assets);
     }
 
-    function deallocate(bytes memory, uint256) external view returns (bytes32[] memory, uint256) {
-        return (ids, 0);
+    function deallocate(bytes memory, uint256 assets) external view returns (bytes32[] memory, uint256, uint256) {
+        return (ids, 0, assets);
     }
 
     function realizeLoss(bytes memory) external view returns (bytes32[] memory, uint256) {

--- a/test/mocks/AdapterMock.sol
+++ b/test/mocks/AdapterMock.sol
@@ -19,16 +19,16 @@ contract AdapterMock is IAdapter {
         IERC20(IVaultV2(_vault).asset()).approve(_vault, type(uint256).max);
     }
 
-    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function allocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         recordedAllocateData = data;
         recordedAllocateAssets = assets;
-        return (ids(), 0);
+        return (ids(), 0, assets);
     }
 
-    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256) {
+    function deallocate(bytes memory data, uint256 assets) external returns (bytes32[] memory, uint256, uint256) {
         recordedDeallocateData = data;
         recordedDeallocateAssets = assets;
-        return (ids(), 0);
+        return (ids(), 0, assets);
     }
 
     function realizeLoss(bytes memory) external pure returns (bytes32[] memory, uint256) {


### PR DESCRIPTION
Add an argument to avoid using an int in `deallocate`

- [ ] Add tests