### PR TITLE
Test: small fixes

### DIFF
--- a/test/AccruingFunctionsTest.sol
+++ b/test/AccruingFunctionsTest.sol
@@ -16,7 +16,7 @@ contract EmptyAdapter is IAdapter {
     }
 }
 
-contract AccrueInterestTest is BaseTest {
+contract AccruingFunctionsTest is BaseTest {
     EmptyAdapter adapter;
 
     function setUp() public override {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -80,7 +80,7 @@ contract BaseTest is Test {
     function increaseRelativeCap(bytes memory idData, uint256 relativeCap) internal {
         bytes32 id = keccak256(idData);
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.increaseRelativeCap.selector, idData, relativeCap));
+        vault.submit(abi.encodeCall(IVaultV2.increaseRelativeCap, (idData, relativeCap)));
         vault.increaseRelativeCap(idData, relativeCap);
         assertEq(vault.relativeCap(id), relativeCap);
     }

--- a/test/RealizeLossTest.sol
+++ b/test/RealizeLossTest.sol
@@ -39,7 +39,7 @@ contract RealizeLossTest is BaseTest {
         adapter = new MockAdapter();
 
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.setIsAdapter.selector, address(adapter), true));
+        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
         vault.setIsAdapter(address(adapter), true);
 
         deal(address(underlyingToken), address(this), type(uint256).max);
@@ -120,15 +120,15 @@ contract RealizeLossTest is BaseTest {
         expectedLoss = bound(expectedLoss, 0, deposit);
 
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.setIsAdapter.selector, address(adapter), true));
+        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
         vault.setIsAdapter(address(adapter), true);
         vm.prank(allocator);
         vault.setLiquidityMarket(address(adapter), hex"");
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.increaseAbsoluteCap.selector, idData, deposit));
+        vault.submit(abi.encodeCall(IVaultV2.increaseAbsoluteCap, (idData, deposit)));
         vault.increaseAbsoluteCap(idData, deposit);
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.increaseRelativeCap.selector, idData, WAD));
+        vault.submit(abi.encodeCall(IVaultV2.increaseRelativeCap, (idData, WAD)));
         vault.increaseRelativeCap(idData, WAD);
 
         vault.deposit(deposit, address(this));

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -305,7 +305,7 @@ contract SettersTest is BaseTest {
 
         // Can abdicate submit
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.abdicateSubmit.selector, selector));
+        vault.submit(abi.encodeCall(IVaultV2.abdicateSubmit, (selector)));
         vm.expectEmit();
         emit EventsLib.AbdicateSubmit(selector);
         vm.warp(vm.getBlockTimestamp() + TIMELOCK_CAP);
@@ -317,10 +317,10 @@ contract SettersTest is BaseTest {
         if (selector == IVaultV2.decreaseTimelock.selector) {
             vm.expectRevert(stdError.arithmeticError);
             vm.prank(curator);
-            vault.submit(abi.encodeWithSelector(IVaultV2.decreaseTimelock.selector, selector, 1 weeks));
+            vault.submit(abi.encodeCall(IVaultV2.decreaseTimelock, (selector, 1 weeks)));
         } else {
             vm.prank(curator);
-            vault.submit(abi.encodeWithSelector(IVaultV2.decreaseTimelock.selector, selector, 1 weeks));
+            vault.submit(abi.encodeCall(IVaultV2.decreaseTimelock, (selector, 1 weeks)));
             vm.warp(vm.getBlockTimestamp() + TIMELOCK_CAP);
             vm.expectRevert(ErrorsLib.InfiniteTimelock.selector);
             vault.decreaseTimelock(selector, 1 weeks);
@@ -724,7 +724,7 @@ contract SettersTest is BaseTest {
 
         // Normal path
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.setSharesGate.selector, newSharesGate));
+        vault.submit(abi.encodeCall(IVaultV2.setSharesGate, (newSharesGate)));
         vm.expectEmit();
         emit EventsLib.SetSharesGate(newSharesGate);
         vault.setSharesGate(newSharesGate);
@@ -742,7 +742,7 @@ contract SettersTest is BaseTest {
 
         // Normal path
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.setReceiveAssetsGate.selector, newReceiveAssetsGate));
+        vault.submit(abi.encodeCall(IVaultV2.setReceiveAssetsGate, (newReceiveAssetsGate)));
         vm.expectEmit();
         emit EventsLib.SetReceiveAssetsGate(newReceiveAssetsGate);
         vault.setReceiveAssetsGate(newReceiveAssetsGate);
@@ -760,7 +760,7 @@ contract SettersTest is BaseTest {
 
         // Normal path
         vm.prank(curator);
-        vault.submit(abi.encodeWithSelector(IVaultV2.setSendAssetsGate.selector, newSendAssetsGate));
+        vault.submit(abi.encodeCall(IVaultV2.setSendAssetsGate, (newSendAssetsGate)));
         vm.expectEmit();
         emit EventsLib.SetSendAssetsGate(newSendAssetsGate);
         vault.setSendAssetsGate(newSendAssetsGate);

--- a/test/ViewFunctionsTest.sol
+++ b/test/ViewFunctionsTest.sol
@@ -16,19 +16,19 @@ contract ViewFunctionsTest is BaseTest {
     }
 
     function testMaxDeposit() public view {
-        assertEq(VaultV2(address(vault)).maxDeposit(receiver), 0);
+        assertEq(vault.maxDeposit(receiver), 0);
     }
 
     function testMaxMint() public view {
-        assertEq(VaultV2(address(vault)).maxMint(receiver), 0);
+        assertEq(vault.maxMint(receiver), 0);
     }
 
     function testMaxWithdraw() public view {
-        assertEq(VaultV2(address(vault)).maxWithdraw(address(this)), 0);
+        assertEq(vault.maxWithdraw(address(this)), 0);
     }
 
     function testMaxRedeem() public view {
-        assertEq(VaultV2(address(vault)).maxRedeem(address(this)), 0);
+        assertEq(vault.maxRedeem(address(this)), 0);
     }
 
     function testConvertToAssets(uint256 initialDeposit, uint256 interest, uint256 shares) public {
@@ -39,10 +39,7 @@ contract ViewFunctionsTest is BaseTest {
         vault.deposit(initialDeposit, address(this));
         writeTotalAssets(initialDeposit + interest);
 
-        assertEq(
-            IVaultV2(address(vault)).convertToAssets(shares),
-            shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1)
-        );
+        assertEq(vault.convertToAssets(shares), shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1));
     }
 
     function testConvertToShares(uint256 initialDeposit, uint256 interest, uint256 assets) public {
@@ -53,10 +50,7 @@ contract ViewFunctionsTest is BaseTest {
         vault.deposit(initialDeposit, address(this));
         writeTotalAssets(initialDeposit + interest);
 
-        assertEq(
-            IVaultV2(address(vault)).convertToShares(assets),
-            assets * (vault.totalSupply() + 1) / (vault.totalAssets() + 1)
-        );
+        assertEq(vault.convertToShares(assets), assets * (vault.totalSupply() + 1) / (vault.totalAssets() + 1));
     }
 
     function testPreviewDeposit(uint256 initialDeposit, uint256 interest, uint256 assets) public {
@@ -68,8 +62,7 @@ contract ViewFunctionsTest is BaseTest {
         writeTotalAssets(initialDeposit + interest);
 
         assertEq(
-            IVaultV2(address(vault)).previewDeposit(initialDeposit),
-            initialDeposit * (vault.totalSupply() + 1) / (vault.totalAssets() + 1)
+            vault.previewDeposit(initialDeposit), initialDeposit * (vault.totalSupply() + 1) / (vault.totalAssets() + 1)
         );
     }
 
@@ -82,11 +75,7 @@ contract ViewFunctionsTest is BaseTest {
         writeTotalAssets(initialDeposit + interest);
 
         // Precision 1 because rounded up.
-        assertApproxEqAbs(
-            IVaultV2(address(vault)).previewMint(shares),
-            shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1),
-            1
-        );
+        assertApproxEqAbs(vault.previewMint(shares), shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1), 1);
     }
 
     function testPreviewWithdraw(uint256 initialDeposit, uint256 interest, uint256 assets) public {
@@ -99,9 +88,7 @@ contract ViewFunctionsTest is BaseTest {
 
         // Precision 1 because rounded up.
         assertApproxEqAbs(
-            IVaultV2(address(vault)).previewWithdraw(assets),
-            assets * (vault.totalSupply() + 1) / (vault.totalAssets() + 1),
-            1
+            vault.previewWithdraw(assets), assets * (vault.totalSupply() + 1) / (vault.totalAssets() + 1), 1
         );
     }
 
@@ -114,9 +101,7 @@ contract ViewFunctionsTest is BaseTest {
         writeTotalAssets(initialDeposit + interest);
 
         assertApproxEqAbs(
-            IVaultV2(address(vault)).previewRedeem(shares),
-            shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1),
-            1
+            vault.previewRedeem(shares), shares * (vault.totalAssets() + 1) / (vault.totalSupply() + 1), 1
         );
     }
 }


### PR DESCRIPTION
This PR:
- makes so contracts have the name of the basename of the file they are in
- remove unnecessary casts
- encodeWithSelector -> encodeCall everywhere