### PR TITLE
Test: partially allocate

### DIFF
--- a/test/AllocateTest.sol
+++ b/test/AllocateTest.sol
@@ -34,9 +34,12 @@ contract AllocateTest is BaseTest {
         vault.allocate(adapter, hex"", 0);
     }
 
-    function testAllocate(bytes memory data, uint256 assets, address rdm, uint256 absoluteCap) public {
+    function testAllocate(bytes memory data, uint256 assets, uint256 allocateAssets, address rdm, uint256 absoluteCap)
+        public
+    {
         vm.assume(rdm != address(allocator));
         assets = bound(assets, 2, type(uint128).max);
+        allocateAssets = bound(allocateAssets, 0, assets);
         absoluteCap = bound(absoluteCap, assets, type(uint128).max);
 
         // Setup.
@@ -92,14 +95,18 @@ contract AllocateTest is BaseTest {
         increaseRelativeCap("id-1", WAD);
         vm.prank(allocator);
         vm.expectEmit();
-        emit EventsLib.Allocate(allocator, adapter, assets, ids, 0);
-        vault.allocate(adapter, data, assets);
-        assertEq(underlyingToken.balanceOf(address(vault)), 0, "Vault balance should be zero after allocation");
-        assertEq(underlyingToken.balanceOf(adapter), assets, "Adapter balance incorrect after allocation");
-        assertEq(vault.allocation(keccak256("id-0")), assets, "Allocation incorrect after allocation");
-        assertEq(vault.allocation(keccak256("id-1")), assets, "Allocation incorrect after allocation");
+        emit EventsLib.Allocate(allocator, adapter, allocateAssets, ids, 0);
+        vault.allocate(adapter, data, allocateAssets);
+        assertEq(
+            underlyingToken.balanceOf(address(vault)),
+            assets - allocateAssets,
+            "Vault balance should be zero after allocation"
+        );
+        assertEq(underlyingToken.balanceOf(adapter), allocateAssets, "Adapter balance incorrect after allocation");
+        assertEq(vault.allocation(keccak256("id-0")), allocateAssets, "Allocation incorrect after allocation");
+        assertEq(vault.allocation(keccak256("id-1")), allocateAssets, "Allocation incorrect after allocation");
         assertEq(AdapterMock(adapter).recordedAllocateData(), data, "Data incorrect after allocation");
-        assertEq(AdapterMock(adapter).recordedAllocateAssets(), assets, "Assets incorrect after allocation");
+        assertEq(AdapterMock(adapter).recordedAllocateAssets(), allocateAssets, "Assets incorrect after allocation");
         assertEq(
             AdapterMock(adapter).recordedSelector(), IVaultV2.allocate.selector, "Selector incorrect after allocation"
         );


### PR DESCRIPTION
Addresses Zellic finding about untested features:
- invalid IDs are actually tested, when caps are not increased prior to allocating/deallocating
- this is tested for `forceDeallocate` as well since it does a deallocation internally
- only remaining thing not tested was that the decrease of idle assets was exactly the allocation when partially allocating (bottom of page 27 in draft report)