### PR TITLE
[Certora] Fix typo reentrancy spec

### DIFF
--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -21,7 +21,7 @@ methods {
     function _.withdraw(uint256, address, address) external => ignoredCallUintSummary() expect uint256;
 
     function _.transfer(address, uint256) external => ignoredCallBoolSummary() expect bool;
-    function _.transferFrom(address, address, uint256) external => hignoredCallBoolSummary() expect bool;
+    function _.transferFrom(address, address, uint256) external => ignoredCallBoolSummary() expect bool;
     function _.balanceOf(address) external => ignoredCallUintSummary() expect uint256;
 }
 


### PR DESCRIPTION
This PR fixes typo that makes the verification fail.