### PR TITLE
Withdraw zero accrue interest

### DIFF
--- a/src/adapters/MorphoVaultV1Adapter.sol
+++ b/src/adapters/MorphoVaultV1Adapter.sol
@@ -88,7 +88,7 @@ contract MorphoVaultV1Adapter is IMorphoVaultV1Adapter {
         require(msg.sender == parentVault, NotAuthorized());
 
         // To accrue interest only one time.
-        IERC4626(morphoVaultV1).deposit(0, address(this));
+        IERC4626(morphoVaultV1).withdraw(0, address(this), address(this));
         uint256 interest = IERC4626(morphoVaultV1).previewRedeem(shares).zeroFloorSub(allocation());
 
         if (assets > 0) shares -= IERC4626(morphoVaultV1).withdraw(assets, address(this), address(this));


### PR DESCRIPTION
Fixes:
- #536 

Putting this as draft because I'm actually not convinced: this should be a no-op, but changing `deposit` into `withdraw` will make the life of auditors worse, because they also need to check on MM that a withdraw 0 is a no-op (on top of checking that deposit 0 is a no-op)

