### PR TITLE
Perf: remove deposit 0

### DIFF
--- a/src/adapters/MorphoMarketV1Adapter.sol
+++ b/src/adapters/MorphoMarketV1Adapter.sol
@@ -73,9 +73,6 @@ contract MorphoMarketV1Adapter is IMorphoMarketV1Adapter {
         require(msg.sender == parentVault, NotAuthorized());
         require(marketParams.loanToken == asset, LoanAssetMismatch());
 
-        // To accrue interest only one time.
-        IMorpho(morpho).accrueInterest(marketParams);
-
         uint256 interest = expectedSupplyAssets(marketParams, shares[marketId]).zeroFloorSub(allocation(marketParams));
 
         if (assets > 0) {
@@ -96,9 +93,6 @@ contract MorphoMarketV1Adapter is IMorphoMarketV1Adapter {
         Id marketId = marketParams.id();
         require(msg.sender == parentVault, NotAuthorized());
         require(marketParams.loanToken == asset, LoanAssetMismatch());
-
-        // To accrue interest only one time.
-        IMorpho(morpho).accrueInterest(marketParams);
 
         uint256 interest = expectedSupplyAssets(marketParams, shares[marketId]).zeroFloorSub(allocation(marketParams));
 

--- a/src/adapters/MorphoVaultV1Adapter.sol
+++ b/src/adapters/MorphoVaultV1Adapter.sol
@@ -69,8 +69,6 @@ contract MorphoVaultV1Adapter is IMorphoVaultV1Adapter {
         require(data.length == 0, InvalidData());
         require(msg.sender == parentVault, NotAuthorized());
 
-        // To accrue interest only one time.
-        IERC4626(morphoVaultV1).deposit(0, address(this));
         uint256 interest = IERC4626(morphoVaultV1).previewRedeem(shares).zeroFloorSub(allocation());
 
         if (assets > 0) shares += IERC4626(morphoVaultV1).deposit(assets, address(this));
@@ -87,8 +85,6 @@ contract MorphoVaultV1Adapter is IMorphoVaultV1Adapter {
         require(data.length == 0, InvalidData());
         require(msg.sender == parentVault, NotAuthorized());
 
-        // To accrue interest only one time.
-        IERC4626(morphoVaultV1).deposit(0, address(this));
         uint256 interest = IERC4626(morphoVaultV1).previewRedeem(shares).zeroFloorSub(allocation());
 
         if (assets > 0) shares -= IERC4626(morphoVaultV1).withdraw(assets, address(this), address(this));


### PR DESCRIPTION
it's actually not an opti:
- intuition for metamorpho is that accrueInterest is actually still very heavy even if done earlier in the block
- less clear for morpho markets, but the overhead of accrueInterest is ~2000, which is not null

replaces #571 