### PR TITLE
Update salt parameter in ManualVicFactory

### DIFF
--- a/src/vic/ManualVicFactory.sol
+++ b/src/vic/ManualVicFactory.sol
@@ -16,7 +16,7 @@ contract ManualVicFactory is IManualVicFactory {
 
     /// @dev Returns the address of the deployed ManualVic.
     function createManualVic(address vault) external returns (address) {
-        address vic = address(new ManualVic{salt: 0}(vault));
+        address vic = address(new ManualVic{salt: bytes32(0)}(vault));
 
         isManualVic[vic] = true;
         manualVic[vault] = vic;


### PR DESCRIPTION
Update `ManualVicFactory` to use `bytes32(0)` for the salt parameter, ensuring consistency with other factories.