### PR TITLE
Add comment about rounding in realizeLoss

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -712,7 +712,7 @@ contract VaultV2 is IVaultV2 {
     }
 
     /// @dev Returns incentiveShares, loss.
-    /// @dev For small losses, it can be that the incentive is null due to rounding errors
+    /// @dev For small losses, it can be that the incentive is null due to rounding errors.
     function realizeLoss(address adapter, bytes memory data) external returns (uint256, uint256) {
         require(isAdapter[adapter], ErrorsLib.NotAdapter());
 


### PR DESCRIPTION
Add a `@dev` comment to `realizeLoss` explaining that small losses might result in a null incentive due to rounding errors.