### PR TITLE
chore: lower optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 via_ir = true
 optimizer = true
-optimizer_runs = 999999 # Etherscan does not support verifying contracts with more optimization runs.
+optimizer_runs = 100000 # Etherscan does not support verifying contracts with more optimization runs.
 bytecode_hash = "none"
 evm_version = "cancun"
 dynamic_test_linking = true


### PR DESCRIPTION
to pass below the contract size limit (we gain 2000B!)

[gas-before.txt](https://github.com/user-attachments/files/21231181/gas-before.txt)

[gas-after.txt](https://github.com/user-attachments/files/21231186/gas-after.txt)

the gas diff is almost null for the median case (<10 gas)