### PR TITLE
Document vault transient storage requirement

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -179,7 +179,8 @@ contract VaultV2 is IVaultV2 {
     mapping(address account => uint256) public nonces;
 
     /* INTEREST STORAGE */
-
+    /// @dev This vault relies on Solidity's `transient` storage (EIP-1153). Deployment must target a
+    ///      chain that supports the TSTORE and TLOAD opcodes.
     uint256 public transient firstTotalAssets;
     uint192 public _totalAssets;
     uint64 public lastUpdate;


### PR DESCRIPTION
Add a comment to `VaultV2.sol` documenting its reliance on transient storage (EIP-1153) and the need for TSTORE/TLOAD opcodes.

---

[Open in Web](https://cursor.com/agents?id=bc-8851e1b4-5389-4f52-84ff-049bc5263171) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8851e1b4-5389-4f52-84ff-049bc5263171) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)