### PR TITLE
docs: re-entering adapters/markets (chainsec 7.4 and competition 282)

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -69,6 +69,8 @@ import {ISharesGate, IReceiveAssetsGate, ISendAssetsGate} from "./interfaces/IGa
 /// - They must make it possible to make deallocate possible (for in-kind redemptions).
 /// - Adapters' returned ids do not repeat.
 /// - They ignore donations of shares in their respective markets.
+/// - They must not re-enter (directly or indirectly) the vault. They might not statically prevent it, but the curator
+/// must not interact with markets that can re-enter the vault.
 /// - Given a method used by the adapter to estimate its assets in a market and a method to track its allocation to a
 /// market:
 ///   - When calculating interest, it must be the positive change between the estimate and the tracked allocation, if

--- a/src/adapters/MorphoMarketV1Adapter.sol
+++ b/src/adapters/MorphoMarketV1Adapter.sol
@@ -15,6 +15,7 @@ import {MathLib} from "../libraries/MathLib.sol";
 /// @dev Morpho Market v1 is also known as Morpho Blue.
 /// @dev This adapter must be used with Morpho Market v1 that are protected against inflation attacks with an initial
 /// supply. Following resource is relevant: https://docs.openzeppelin.com/contracts/5.x/erc4626#inflation-attack.
+/// @dev Must not be used with a Morpho Market v1 with an Irm that can re-enter the parent vault.
 contract MorphoMarketV1Adapter is IMorphoMarketV1Adapter {
     using MathLib for uint256;
     using SharesMathLib for uint256;

--- a/src/adapters/MorphoVaultV1Adapter.sol
+++ b/src/adapters/MorphoVaultV1Adapter.sol
@@ -15,6 +15,7 @@ import {MathLib} from "../libraries/MathLib.sol";
 /// corresponding bad debt.
 /// @dev This adapter must be used with Morpho Vaults v1 that are protected against inflation attacks with an initial
 /// deposit. See https://docs.openzeppelin.com/contracts/5.x/erc4626#inflation-attack.
+/// @dev Must not be used with a Morpho Vault v1 which has a market with an Irm that can re-enter the parent vault.
 contract MorphoVaultV1Adapter is IMorphoVaultV1Adapter {
     using MathLib for uint256;
 


### PR DESCRIPTION
fixes chainsec 7.4 and https://cantina.xyz/code/523e1540-f8c3-45ae-9c5d-b6d35d3a326c/findings/282