### PR TITLE
separate adapter alloc from id alloc

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -578,9 +578,6 @@ contract VaultV2 is IVaultV2 {
 
     function accrueInterest() public {
         if (lastUpdate != block.timestamp) {
-            // (uint256 newTotalAssets, uint256 performanceFeeShares, uint256 managementFeeShares) =
-            // accrueInterestView();
-
             (uint256 elapsed, uint256 tentativeInterest) = vicInterest();
             (uint256 newTotalAssets, uint256 performanceFeeShares, uint256 managementFeeShares) =
                 _accrueInterestView(elapsed, tentativeInterest);
@@ -600,9 +597,6 @@ contract VaultV2 is IVaultV2 {
     /// @dev The performance and management fees are taken even if the vault incurs some losses.
     /// @dev Both fees are rounded down, so fee recipients could receive less than expected.
     function accrueInterestView() public view returns (uint256, uint256, uint256) {
-        // uint256 elapsed = block.timestamp - lastUpdate;
-        // if (elapsed == 0) return (_totalAssets, 0, 0);
-
         (uint256 elapsed, uint256 tentativeInterest) = vicInterestView();
         return _accrueInterestView(elapsed, tentativeInterest);
     }

--- a/src/adapters/MorphoMarketV1Adapter.sol
+++ b/src/adapters/MorphoMarketV1Adapter.sol
@@ -11,7 +11,6 @@ import {IERC20} from "../interfaces/IERC20.sol";
 import {IMorphoMarketV1Adapter} from "./interfaces/IMorphoMarketV1Adapter.sol";
 import {SafeERC20Lib} from "../libraries/SafeERC20Lib.sol";
 import {MathLib} from "../libraries/MathLib.sol";
-import "forge-std/console.sol";
 
 /// @dev Morpho Market v1 is also known as Morpho Blue.
 /// @dev This adapter must be used with Morpho Market v1 that are protected against inflation attacks with an initial
@@ -84,11 +83,6 @@ contract MorphoMarketV1Adapter is IMorphoMarketV1Adapter {
         marketAssets[marketId] = marketAssetsNoLoss + assets;
         uint256 interest = marketAssetsNoLoss.zeroFloorSub(allocation(marketParams));
 
-        console.log("allocate: marketAssets", marketAssets[marketParams.id()]);
-        console.log("allocate: ID");
-        console.logBytes32(Id.unwrap(marketParams.id()));
-        console.log("allocate: interest", interest);
-
         if (assets > 0) {
             (, uint256 mintedShares) = IMorpho(morpho).supply(marketParams, assets, 0, address(this), hex"");
             shares[marketId] += mintedShares;
@@ -137,12 +131,7 @@ contract MorphoMarketV1Adapter is IMorphoMarketV1Adapter {
         require(marketParams.loanToken == asset, LoanAssetMismatch());
 
         uint256 realAssets = expectedSupplyAssets(marketParams, shares[marketParams.id()]);
-        console.log("a");
         uint256 allocationLoss = allocation(marketParams) - realAssets;
-        console.log("realizeLoss: allocation", allocation(marketParams));
-        console.log("realizeLoss: marketAssets", marketAssets[marketParams.id()]);
-        console.log("realizeLoss: ID");
-        console.logBytes32(Id.unwrap(marketParams.id()));
         uint256 assetLoss = marketAssets[marketParams.id()] - realAssets;
 
         marketAssets[marketParams.id()] = realAssets;

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -17,7 +17,8 @@ interface IAdapter {
     /// @dev Returns the market' ids and the loss occurred on this market.
     function realizeLoss(bytes memory data, bytes4 selector, address sender)
         external
-        returns (bytes32[] memory ids, uint256 loss);
+        returns (bytes32[] memory ids, uint256 allocationLoss, uint256 assetLoss);
 
-    function totalAssetsNoLoss() external view returns (uint256 assets);
+    function totalAssetsNoLoss() external returns (uint256 assets);
+    function totalAssetsNoLossView() external view returns (uint256 assets);
 }

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -101,5 +101,7 @@ interface IVaultV2 is IERC4626, IERC2612 {
         returns (uint256 penaltyShares);
 
     // Realize loss
-    function realizeLoss(address adapter, bytes memory data) external returns (uint256 incentiveShares, uint256 loss);
+    function realizeLoss(address adapter, bytes memory data)
+        external
+        returns (uint256 incentiveShares, uint256 allocationLoss, uint256 assetLoss);
 }

--- a/src/interfaces/IVic.sol
+++ b/src/interfaces/IVic.sol
@@ -3,5 +3,6 @@
 pragma solidity >=0.5.0;
 
 interface IVic {
-    function interest(uint256 totalAssets, uint256 elapsed) external view returns (uint256);
+    function interest(uint256 totalAssets, uint256 elapsed) external returns (uint256);
+    function interestView(uint256 totalAssets, uint256 elapsed) external view returns (uint256);
 }

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -34,7 +34,12 @@ library EventsLib {
 
     // Loss realization events
     event RealizeLoss(
-        address indexed sender, address indexed adapter, bytes32[] ids, uint256 loss, uint256 incentiveShares
+        address indexed sender,
+        address indexed adapter,
+        bytes32[] ids,
+        uint256 allocationLoss,
+        uint256 assetLoss,
+        uint256 incentiveShares
     );
 
     // Fee and interest events

--- a/src/vic/ManualVic.sol
+++ b/src/vic/ManualVic.sol
@@ -62,7 +62,12 @@ contract ManualVic is IManualVic {
     }
 
     /// @dev Returns the interest per second.
-    function interest(uint256, uint256 elapsed) external view returns (uint256) {
+    function interest(uint256 totalAssets, uint256 elapsed) external view returns (uint256) {
+        return interestView(totalAssets, elapsed);
+    }
+
+    /// @dev Returns the interest per second.
+    function interestView(uint256, uint256 elapsed) public view returns (uint256) {
         uint256 lastUpdate = block.timestamp - elapsed;
         if (block.timestamp <= deadline) {
             return storedInterestPerSecond * elapsed;

--- a/src/vic/OnchainVic.sol
+++ b/src/vic/OnchainVic.sol
@@ -25,10 +25,19 @@ contract OnchainVic is IOnchainVic {
     }
 
     /// @dev Returns the interest per second.
-    function interest(uint256 totalAssets, uint256) external view returns (uint256) {
+    function interest(uint256 totalAssets, uint256) external returns (uint256) {
         uint256 realAssets = IERC20(asset).balanceOf(parentVault);
         for (uint256 i = 0; i < IVaultV2(parentVault).adaptersLength(); i++) {
             realAssets += IAdapter(IVaultV2(parentVault).adapters(i)).totalAssetsNoLoss();
+        }
+        return realAssets - totalAssets;
+    }
+
+    /// @dev Returns the interest per second.
+    function interestView(uint256 totalAssets, uint256) external view returns (uint256) {
+        uint256 realAssets = IERC20(asset).balanceOf(parentVault);
+        for (uint256 i = 0; i < IVaultV2(parentVault).adaptersLength(); i++) {
+            realAssets += IAdapter(IVaultV2(parentVault).adapters(i)).totalAssetsNoLossView();
         }
         return realAssets - totalAssets;
     }

--- a/test/RealizeLossTest.sol
+++ b/test/RealizeLossTest.sol
@@ -65,11 +65,13 @@ contract RealizeLossTest is BaseTest {
         uint256 sharesBefore = vault.balanceOf(address(this));
         bytes32[] memory emptyIds = new bytes32[](0);
         vm.expectEmit(true, true, false, false);
-        emit EventsLib.RealizeLoss(address(this), address(adapter), emptyIds, 0, 0);
-        (uint256 incentiveShares, uint256 loss) = vault.realizeLoss(address(adapter), hex"");
+        emit EventsLib.RealizeLoss(address(this), address(adapter), emptyIds, 0, 0, 0);
+        (uint256 incentiveShares, uint256 allocationLoss, uint256 assetLoss) =
+            vault.realizeLoss(address(adapter), hex"");
         uint256 expectedShares = vault.balanceOf(address(this)) - sharesBefore;
         assertEq(incentiveShares, expectedShares, "incentive shares should be equal to expected shares");
-        assertEq(loss, expectedLoss, "loss should be equal to expected loss");
+        assertEq(allocationLoss, expectedLoss, "allocation loss should be equal to expected loss");
+        assertEq(assetLoss, expectedLoss, "asset loss should be equal to expected loss");
         assertEq(vault.totalAssets(), deposit - expectedLoss, "total assets should have decreased by the loss");
     }
 

--- a/test/mocks/AdapterMock.sol
+++ b/test/mocks/AdapterMock.sol
@@ -62,10 +62,13 @@ contract AdapterMock is IAdapter {
         return (ids(), interest);
     }
 
-    function realizeLoss(bytes memory, bytes4 selector, address sender) external returns (bytes32[] memory, uint256) {
+    function realizeLoss(bytes memory, bytes4 selector, address sender)
+        external
+        returns (bytes32[] memory, uint256, uint256)
+    {
         recordedSelector = selector;
         recordedSender = sender;
-        return (ids(), loss);
+        return (ids(), loss, loss);
     }
 
     function ids() internal view returns (bytes32[] memory) {
@@ -73,6 +76,10 @@ contract AdapterMock is IAdapter {
     }
 
     function totalAssetsNoLoss() external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalAssetsNoLossView() external pure returns (uint256) {
         return 0;
     }
 }

--- a/test/mocks/VaultV2Mock.sol
+++ b/test/mocks/VaultV2Mock.sol
@@ -45,11 +45,15 @@ contract VaultV2Mock {
         return (ids, interest);
     }
 
-    function realizeLossMocked(address adapter, bytes memory data) external returns (bytes32[] memory, uint256) {
-        (bytes32[] memory ids, uint256 loss) = IAdapter(adapter).realizeLoss(data, msg.sig, msg.sender);
+    function realizeLossMocked(address adapter, bytes memory data)
+        external
+        returns (bytes32[] memory, uint256, uint256)
+    {
+        (bytes32[] memory ids, uint256 allocationLoss, uint256 assetLoss) =
+            IAdapter(adapter).realizeLoss(data, msg.sig, msg.sender);
         for (uint256 i; i < ids.length; i++) {
-            allocation[ids[i]] -= loss;
+            allocation[ids[i]] -= allocationLoss;
         }
-        return (ids, loss);
+        return (ids, allocationLoss, assetLoss);
     }
 }


### PR DESCRIPTION
see [thread 1](https://morpholabs.slack.com/archives/C08A40KKN9W/p1753792178398129) and [thread 2](https://morpholabs.slack.com/archives/C08A40KKN9W/p1753793270585419)

invariant: allocationLoss <= assetLoss
invariant: allocation[marketParams] <= adapter.marketAssets[marketParams]
invariant: allocation[vault] <= adapter.vaultAssets