### PR TITLE
Vault shares donation protection

### DIFF
--- a/src/adapters/MorphoVaultV1Adapter.sol
+++ b/src/adapters/MorphoVaultV1Adapter.sol
@@ -105,6 +105,8 @@ contract MorphoVaultV1Adapter is IMorphoVaultV1Adapter {
     }
 
     function realAssets() external view returns (uint256) {
-        return IERC4626(morphoVaultV1).previewRedeem(IERC4626(morphoVaultV1).balanceOf(address(this)));
+        return allocation() != 0
+            ? IERC4626(morphoVaultV1).previewRedeem(IERC4626(morphoVaultV1).balanceOf(address(this)))
+            : 0;
     }
 }

--- a/test/integration/MorphoVaultV1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1IntegrationDonationTest.sol
@@ -9,7 +9,7 @@ contract MorphoVaultV1IntegrationDonationTest is MorphoVaultV1IntegrationTest {
 
     address internal immutable donor = makeAddr("donor");
 
-    function testSharesDonationResistance(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
         initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
         donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
         elapsed = bound(elapsed, 0, 10 * 365 days);

--- a/test/integration/MorphoVaultV1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1IntegrationDonationTest.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import "./MorphoVaultV1IntegrationTest.sol";
+
+contract MorphoVaultV1IntegrationDonationTest is MorphoVaultV1IntegrationTest {
+    using MorphoBalancesLib for IMorpho;
+
+    address internal immutable donor = makeAddr("donor");
+
+    function testSharesDonationResistance(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+        initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
+        donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
+        elapsed = bound(elapsed, 0, 10 * 365 days);
+
+        setSupplyQueueIdle();
+
+        vault.deposit(initialAssets, address(this));
+
+        assertEq(vault.totalAssets(), initialAssets, "initialAssets");
+
+        deal(address(underlyingToken), donor, donatedAssets);
+        vm.startPrank(donor);
+        underlyingToken.approve(address(morphoVaultV1), type(uint256).max);
+        morphoVaultV1.deposit(donatedAssets, address(morphoVaultV1Adapter));
+        vm.stopPrank();
+
+        assertEq(underlyingToken.balanceOf(address(morpho)), donatedAssets, "underlying balance of Morpho");
+        assertEq(morphoVaultV1.previewRedeem(morphoVaultV1.balanceOf(address(morphoVaultV1Adapter))), donatedAssets);
+        assertEq(underlyingToken.balanceOf(address(morphoVaultV1Adapter)), 0, "underlying balance of adapter");
+        assertEq(underlyingToken.balanceOf(address(vault)), initialAssets, "underlying balance of vault");
+        assertEq(
+            morpho.expectedSupplyAssets(idleParams, address(morphoVaultV1)),
+            donatedAssets,
+            "expected donatedAssets of morphoVaultV1"
+        );
+
+        skip(elapsed);
+        assertEq(vault.totalAssets(), initialAssets, "not donation resistant");
+    }
+}

--- a/test/integration/MorphoVaultV1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1IntegrationDonationTest.sol
@@ -9,7 +9,9 @@ contract MorphoVaultV1IntegrationDonationTest is MorphoVaultV1IntegrationTest {
 
     address internal immutable donor = makeAddr("donor");
 
-    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed)
+        public
+    {
         initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
         donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
         elapsed = bound(elapsed, 0, 10 * 365 days);

--- a/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
@@ -9,7 +9,7 @@ contract MorphoVaultV1_1IntegrationDonationTest is MorphoVaultV1_1IntegrationTes
 
     address internal immutable donor = makeAddr("donor");
 
-    function testSharesDonationResistance(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
         initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
         donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
         elapsed = bound(elapsed, 0, 10 * 365 days);

--- a/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
@@ -9,7 +9,9 @@ contract MorphoVaultV1_1IntegrationDonationTest is MorphoVaultV1_1IntegrationTes
 
     address internal immutable donor = makeAddr("donor");
 
-    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+    function testSharesDonationResistanceIfNoAllocation(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed)
+        public
+    {
         initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
         donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
         elapsed = bound(elapsed, 0, 10 * 365 days);

--- a/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
+++ b/test/integration/MorphoVaultV1_1IntegrationDonationTest.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import "./MorphoVaultV1_1IntegrationTest.sol";
+
+contract MorphoVaultV1_1IntegrationDonationTest is MorphoVaultV1_1IntegrationTest {
+    using MorphoBalancesLib for IMorpho;
+
+    address internal immutable donor = makeAddr("donor");
+
+    function testSharesDonationResistance(uint256 initialAssets, uint256 donatedAssets, uint256 elapsed) public {
+        initialAssets = bound(initialAssets, 0, MAX_TEST_ASSETS);
+        donatedAssets = bound(donatedAssets, 0, MAX_TEST_ASSETS);
+        elapsed = bound(elapsed, 0, 10 * 365 days);
+
+        setSupplyQueueIdle();
+
+        vault.deposit(initialAssets, address(this));
+
+        assertEq(vault.totalAssets(), initialAssets, "initialAssets");
+
+        deal(address(underlyingToken), donor, donatedAssets);
+        vm.startPrank(donor);
+        underlyingToken.approve(address(morphoVaultV1), type(uint256).max);
+        morphoVaultV1.deposit(donatedAssets, address(morphoVaultV1Adapter));
+        vm.stopPrank();
+
+        assertEq(underlyingToken.balanceOf(address(morpho)), donatedAssets, "underlying balance of Morpho");
+        assertEq(morphoVaultV1.previewRedeem(morphoVaultV1.balanceOf(address(morphoVaultV1Adapter))), donatedAssets);
+        assertEq(underlyingToken.balanceOf(address(morphoVaultV1Adapter)), 0, "underlying balance of adapter");
+        assertEq(underlyingToken.balanceOf(address(vault)), initialAssets, "underlying balance of vault");
+        assertEq(
+            morpho.expectedSupplyAssets(idleParams, address(morphoVaultV1)),
+            donatedAssets,
+            "expected donatedAssets of morphoVaultV1"
+        );
+
+        skip(elapsed);
+        assertEq(vault.totalAssets(), initialAssets, "not donation resistant");
+    }
+}


### PR DESCRIPTION
Fixes [this issue](https://morpholabs.slack.com/archives/C08T1J5MAGJ/p1754556973800259?thread_ts=1753223617.465859&cid=C08T1J5MAGJ).
Rationale: keep the following spec that is written in  VaultV2.sol
"The totalAssets() calculation ignores markets for which the vault has no allocation."