### PR TITLE
refactor: separate setIsAdapter

### DIFF
--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -347,25 +347,28 @@ contract VaultV2 is IVaultV2 {
         emit EventsLib.SetSendAssetsGate(newSendAssetsGate);
     }
 
-    function setIsAdapter(address account, bool newIsAdapter) external {
+    function addAdapter(address account) external {
         timelocked();
+        if (!isAdapter[account]) {
+            adapters.push(account);
+            isAdapter[account] = true;
+        }
+        emit EventsLib.AddAdapter(account);
+    }
 
-        if (isAdapter[account] != newIsAdapter) {
-            if (newIsAdapter) {
-                adapters.push(account);
-            } else {
-                for (uint256 i = 0; i < adapters.length; i++) {
-                    if (adapters[i] == account) {
-                        adapters[i] = adapters[adapters.length - 1];
-                        adapters.pop();
-                        break;
-                    }
+    function removeAdapter(address account) external {
+        timelocked();
+        if (isAdapter[account]) {
+            for (uint256 i = 0; i < adapters.length; i++) {
+                if (adapters[i] == account) {
+                    adapters[i] = adapters[adapters.length - 1];
+                    adapters.pop();
+                    break;
                 }
             }
-            isAdapter[account] = newIsAdapter;
+            isAdapter[account] = false;
         }
-
-        emit EventsLib.SetIsAdapter(account, newIsAdapter);
+        emit EventsLib.RemoveAdapter(account);
     }
 
     function increaseTimelock(bytes4 selector, uint256 newDuration) external {

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -67,7 +67,8 @@ interface IVaultV2 is IERC4626, IERC2612 {
     function setSharesGate(address newSharesGate) external;
     function setReceiveAssetsGate(address newReceiveAssetsGate) external;
     function setSendAssetsGate(address newSendAssetsGate) external;
-    function setIsAdapter(address account, bool newIsAdapter) external;
+    function addAdapter(address account) external;
+    function removeAdapter(address account) external;
     function increaseTimelock(bytes4 selector, uint256 newDuration) external;
     function abdicateSubmit(bytes4 selector) external;
     function decreaseTimelock(bytes4 selector, uint256 newDuration) external;

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -52,7 +52,8 @@ library EventsLib {
     event SetSharesGate(address indexed newSharesGate);
     event SetReceiveAssetsGate(address indexed newReceiveAssetsGate);
     event SetSendAssetsGate(address indexed newSendAssetsGate);
-    event SetIsAdapter(address indexed account, bool newIsAdapter);
+    event AddAdapter(address indexed account);
+    event RemoveAdapter(address indexed account);
     event AbdicateSubmit(bytes4 indexed selector);
     event DecreaseTimelock(bytes4 indexed selector, uint256 newDuration);
     event IncreaseTimelock(bytes4 indexed selector, uint256 newDuration);

--- a/test/AccrueInterestTest.sol
+++ b/test/AccrueInterestTest.sol
@@ -30,8 +30,8 @@ contract AccrueInterestTest is BaseTest {
 
         adapter = new AdapterMock(address(vault));
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         vm.prank(curator);
         vault.submit(abi.encodeCall(IVaultV2.setMaxRate, (MAX_MAX_RATE)));

--- a/test/AccruingFunctionsTest.sol
+++ b/test/AccruingFunctionsTest.sol
@@ -13,8 +13,8 @@ contract AccruingFunctionsTest is BaseTest {
         adapter = new AdapterMock(address(vault));
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         increaseAbsoluteCap("id-0", type(uint128).max);
         increaseAbsoluteCap("id-1", type(uint128).max);

--- a/test/AllocateTest.sol
+++ b/test/AllocateTest.sol
@@ -22,8 +22,8 @@ contract AllocateTest is BaseTest {
         underlyingToken.approve(address(vault), type(uint256).max);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (adapter, true)));
-        vault.setIsAdapter(adapter, true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (adapter)));
+        vault.addAdapter(adapter);
 
         ids = new bytes32[](2);
         ids[0] = keccak256("id-0");

--- a/test/ForceDeallocateTest.sol
+++ b/test/ForceDeallocateTest.sol
@@ -17,8 +17,8 @@ contract ForceDeallocateTest is BaseTest {
 
         adapter = new AdapterMock(address(vault));
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         increaseAbsoluteCap("id-0", type(uint128).max);
         increaseAbsoluteCap("id-1", type(uint128).max);

--- a/test/LiquidityAdapterTest.sol
+++ b/test/LiquidityAdapterTest.sol
@@ -23,8 +23,8 @@ contract LiquidityAdapterTest is BaseTest {
         underlyingToken.approve(address(vault), type(uint256).max);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         increaseAbsoluteCap("id-0", type(uint128).max);
         increaseAbsoluteCap("id-1", type(uint128).max);

--- a/test/RealizeLossTest.sol
+++ b/test/RealizeLossTest.sol
@@ -21,8 +21,8 @@ contract RealizeLossTest is BaseTest {
         adapter = new AdapterMock(address(vault));
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         deal(address(underlyingToken), address(this), type(uint256).max);
         underlyingToken.approve(address(vault), type(uint256).max);
@@ -90,8 +90,8 @@ contract RealizeLossTest is BaseTest {
         expectedLoss = bound(expectedLoss, 1, deposit);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
         vm.prank(allocator);
         vault.setLiquidityAdapterAndData(address(adapter), hex"");
 
@@ -111,8 +111,8 @@ contract RealizeLossTest is BaseTest {
         expectedLoss = bound(expectedLoss, 1, deposit);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
         vm.prank(allocator);
         vault.setLiquidityAdapterAndData(address(adapter), hex"");
 
@@ -132,8 +132,8 @@ contract RealizeLossTest is BaseTest {
         expectedLoss = bound(expectedLoss, 1, deposit);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
         vm.prank(allocator);
         vault.setLiquidityAdapterAndData(address(adapter), hex"");
 

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -219,31 +219,39 @@ contract SettersTest is BaseTest {
         assertFalse(vault.isAllocator(newAllocator));
     }
 
-    function testSetIsAdapter(address rdm) public {
+    function testAddAdapter(address rdm) public {
         vm.assume(rdm != curator);
         address newAdapter = makeAddr("newAdapter");
 
         // Nobody can set directly
         vm.expectRevert(ErrorsLib.DataNotTimelocked.selector);
         vm.prank(rdm);
-        vault.setIsAdapter(newAdapter, true);
+        vault.addAdapter(newAdapter);
 
         // Normal path
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (newAdapter, true)));
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (newAdapter)));
         vm.expectEmit();
-        emit EventsLib.SetIsAdapter(newAdapter, true);
-        vault.setIsAdapter(newAdapter, true);
+        emit EventsLib.AddAdapter(newAdapter);
+        vault.addAdapter(newAdapter);
         assertTrue(vault.isAdapter(newAdapter));
         assertEq(vault.adaptersLength(), 1);
         assertEq(vault.adapters(0), newAdapter);
+    }
+
+    function testRemoveAdapter(address rdm) public {
+        vm.assume(rdm != curator);
+        address newAdapter = makeAddr("newAdapter");
+        vm.prank(curator);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (newAdapter)));
+        vault.addAdapter(newAdapter);
 
         // Removal
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (newAdapter, false)));
+        vault.submit(abi.encodeCall(IVaultV2.removeAdapter, (newAdapter)));
         vm.expectEmit();
-        emit EventsLib.SetIsAdapter(newAdapter, false);
-        vault.setIsAdapter(newAdapter, false);
+        emit EventsLib.RemoveAdapter(newAdapter);
+        vault.removeAdapter(newAdapter);
         assertFalse(vault.isAdapter(newAdapter));
         assertEq(vault.adaptersLength(), 0);
     }
@@ -699,8 +707,8 @@ contract SettersTest is BaseTest {
         // Setup.
         address adapter = makeAddr("adapter");
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (adapter, true)));
-        vault.setIsAdapter(adapter, true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (adapter)));
+        vault.addAdapter(adapter);
 
         // Nobody can set directly
         vm.expectRevert(ErrorsLib.DataNotTimelocked.selector);
@@ -790,8 +798,8 @@ contract SettersTest is BaseTest {
 
         // Normal path
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (liquidityAdapter, true)));
-        vault.setIsAdapter(liquidityAdapter, true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (liquidityAdapter)));
+        vault.addAdapter(liquidityAdapter);
         vm.prank(allocator);
         vm.expectEmit();
         emit EventsLib.SetLiquidityAdapterAndData(allocator, liquidityAdapter, liquidityData);

--- a/test/ViewFunctionsTest.sol
+++ b/test/ViewFunctionsTest.sol
@@ -33,8 +33,8 @@ contract ViewFunctionsTest is BaseTest {
         adapter = new AdapterMock(address(vault));
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         vm.prank(curator);
         vault.submit(abi.encodeCall(IVaultV2.setMaxRate, (MAX_MAX_RATE)));

--- a/test/integration/MorphoMarketV1IntegrationTest.sol
+++ b/test/integration/MorphoMarketV1IntegrationTest.sol
@@ -88,8 +88,8 @@ contract MorphoMarketV1IntegrationTest is BaseTest {
         expectedIdData2[2] = abi.encode("this/marketParams", address(adapter), marketParams2);
 
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(adapter), true)));
-        vault.setIsAdapter(address(adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(adapter))));
+        vault.addAdapter(address(adapter));
 
         vm.prank(curator);
         vault.submit(abi.encodeCall(IVaultV2.setMaxRate, (MAX_MAX_RATE)));

--- a/test/integration/MorphoVaultV1IntegrationTest.sol
+++ b/test/integration/MorphoVaultV1IntegrationTest.sol
@@ -126,8 +126,8 @@ contract MorphoVaultV1IntegrationTest is BaseTest {
 
         bytes memory idData = abi.encode("this", address(morphoVaultV1Adapter));
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(morphoVaultV1Adapter), true)));
-        vault.setIsAdapter(address(morphoVaultV1Adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(morphoVaultV1Adapter))));
+        vault.addAdapter(address(morphoVaultV1Adapter));
 
         vm.prank(curator);
         vault.submit(abi.encodeCall(IVaultV2.setMaxRate, (MAX_MAX_RATE)));

--- a/test/integration/MorphoVaultV1_1IntegrationTest.sol
+++ b/test/integration/MorphoVaultV1_1IntegrationTest.sol
@@ -126,8 +126,8 @@ contract MorphoVaultV1_1IntegrationTest is BaseTest {
 
         bytes memory idData = abi.encode("this", address(morphoVaultV1Adapter));
         vm.prank(curator);
-        vault.submit(abi.encodeCall(IVaultV2.setIsAdapter, (address(morphoVaultV1Adapter), true)));
-        vault.setIsAdapter(address(morphoVaultV1Adapter), true);
+        vault.submit(abi.encodeCall(IVaultV2.addAdapter, (address(morphoVaultV1Adapter))));
+        vault.addAdapter(address(morphoVaultV1Adapter));
 
         vm.prank(curator);
         vault.submit(abi.encodeCall(IVaultV2.setMaxRate, (MAX_MAX_RATE)));


### PR DESCRIPTION
>The risk of one and the other are very different, they must be separated (for example I don't think that people have super clear in mind that removing an adapter is ultra-critical, if it has some assets)

https://morpholabs.slack.com/archives/C02N7CZ088N/p1756225582633999