### PR TITLE
auto `decreaseTimelock` timelock, with 1 year cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ It can:
 The curator's role is to curate the vault, meaning setting risk limits, gates, allocators, fees.
 Only one address can have this role.
 
-Curator actions are timelockable, except decreaseAbsoluteCap and decreaseRelativeCap.
+Curator actions are timelockable (between 0 and 365 days, or infinite if the action has been abdicated), except decreaseAbsoluteCap and decreaseRelativeCap.
 Once the timelock has passed, the action can be executed by anyone.
 
 It can:
@@ -151,6 +151,7 @@ It can:
   The management fee is capped at 5% of assets under management annually.
 - [Timelockable] Set the `performanceFeeRecipient`.
 - [Timelockable] Set the `managementFeeRecipient`.
+- [Timelockable] Abdicate submitting of an action.
   The timelock of increaseTimelock should be set to a safe value that gives time to detect mistakes (e.g. 1 day) after the vault has been created and initial timelocks have been set.
 
 #### Allocator

--- a/certora/helpers/Utils.sol
+++ b/certora/helpers/Utils.sol
@@ -17,6 +17,10 @@ contract Utils {
         return WAD;
     }
 
+    function timelockCap() external pure returns (uint256) {
+        return TIMELOCK_CAP;
+    }
+
     function maxPerformanceFee() external pure returns (uint256) {
         return MAX_PERFORMANCE_FEE;
     }

--- a/certora/specs/AbdicatedFunctions.spec
+++ b/certora/specs/AbdicatedFunctions.spec
@@ -11,6 +11,13 @@ methods {
     function Utils.toBytes4(bytes) external returns bytes4 envfree;
 }
 
+// Check that abdicating a function set their timelock to infinity.
+rule abdicatedFunctionHasInfiniteTimelock(env e, bytes4 selector) {
+    abdicateSubmit(e, selector);
+
+    assert timelock(selector) == max_uint256;
+}
+
 // Check that it is possible to set a function's timelock to uint max.
 rule abdicatedFunctionHasInfiniteTimelock(env e, bytes4 selector) {
     increaseTimelock(e, selector, max_uint256);

--- a/certora/specs/AbdicatedFunctions.spec
+++ b/certora/specs/AbdicatedFunctions.spec
@@ -18,13 +18,6 @@ rule abdicatedFunctionHasInfiniteTimelock(env e, bytes4 selector) {
     assert timelock(selector) == max_uint256;
 }
 
-// Check that it is possible to set a function's timelock to uint max.
-rule abdicatedFunctionHasInfiniteTimelock(env e, bytes4 selector) {
-    increaseTimelock(e, selector, max_uint256);
-
-    assert timelock(selector) == max_uint256;
-}
-
 // Check that changes corresponding to functions that have been abdicated can't be submitted.
 rule abdicatedFunctionsCantBeSubmitted(env e, bytes data) {
     // Safe require in a non trivial chain.
@@ -36,5 +29,22 @@ rule abdicatedFunctionsCantBeSubmitted(env e, bytes data) {
     require timelock(Utils.toBytes4(data)) == max_uint256;
 
     submit@withrevert(e, data);
+    assert lastReverted;
+}
+
+// Check that timelocks corresponding to functions that have been abdicated can't be decreased.
+rule abdicatedFunctionsTimelocksCantBeDecreased(env e, bytes data, uint newDuration) {
+    // Safe require in a non trivial chain.
+    require e.block.timestamp > 0;
+
+    // Noops are allowed
+    require newDuration != type(uint256).max;
+
+    // Check that the function is not decreaseTimelock as its timelock is automatic.
+    require(Utils.toBytes4(data) != to_bytes4(sig:VaultV2.decreaseTimelock(bytes4, uint256).selector));
+    // Assume that the function has been abdicated.
+    require timelock(Utils.toBytes4(data)) == max_uint256;
+
+    decreaseTimelock(Utils.toBytes4(data), newDuration)@withrevert(e, data);
     assert lastReverted;
 }

--- a/certora/specs/Invariants.spec
+++ b/certora/specs/Invariants.spec
@@ -24,6 +24,7 @@ methods {
     function balanceOf(address) external returns uint256 envfree;
 
     function Utils.wad() external returns uint256 envfree;
+    function Utils.timelockCap() external returns uint256 envfree;
     function Utils.maxPerformanceFee() external returns uint256 envfree;
     function Utils.maxManagementFee() external returns uint256 envfree;
     function Utils.maxForceDeallocatePenalty() external returns uint256 envfree;
@@ -60,6 +61,9 @@ strong invariant forceDeallocatePenalty(address adapter)
 
 strong invariant balanceOfZero()
     balanceOf(0) == 0;
+
+strong invariant timelockBounds(bytes4 selector)
+    timelock(selector) <= Utils.timelockCap() || timelock(selector) == max_uint256;
 
 strong invariant decreaseTimelockTimelock()
     timelock(decreaseTimelockSelector()) == 0;

--- a/src/VaultV2.sol
+++ b/src/VaultV2.sol
@@ -318,7 +318,6 @@ contract VaultV2 is IVaultV2 {
         require(executableAt[data] == 0, ErrorsLib.DataAlreadyPending());
 
         bytes4 selector = bytes4(data);
-
         uint256 _timelock = timelock[selector == IVaultV2.decreaseTimelock.selector ? bytes4(data[4:8]) : selector];
 
         require(_timelock != type(uint256).max, ErrorsLib.Abdicated());
@@ -424,7 +423,7 @@ contract VaultV2 is IVaultV2 {
     function decreaseTimelock(bytes4 selector, uint256 newDuration) external {
         timelocked();
         require(selector != IVaultV2.decreaseTimelock.selector, ErrorsLib.TimelockIsAutomatic());
-        require(timelock[selector] != type(uint256).max, ErrorsLib.Abdicated());
+        require(timelock[selector] != type(uint256).max || newDuration == type(uint256).max, ErrorsLib.Abdicated());
         require(newDuration <= timelock[selector], ErrorsLib.TimelockNotDecreasing());
 
         timelock[selector] = newDuration;

--- a/src/interfaces/IVaultV2.sol
+++ b/src/interfaces/IVaultV2.sol
@@ -72,6 +72,7 @@ interface IVaultV2 is IERC4626, IERC2612 {
     function addAdapter(address account) external;
     function removeAdapter(address account) external;
     function increaseTimelock(bytes4 selector, uint256 newDuration) external;
+    function abdicateSubmit(bytes4 selector) external;
     function decreaseTimelock(bytes4 selector, uint256 newDuration) external;
     function setPerformanceFee(uint256 newPerformanceFee) external;
     function setManagementFee(uint256 newManagementFee) external;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -7,6 +7,7 @@ bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,addre
 bytes32 constant PERMIT_TYPEHASH =
     keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 uint256 constant MAX_MAX_RATE = 200e16 / uint256(365 days); // 200% APR
+uint256 constant TIMELOCK_CAP = 365 days;
 uint256 constant MAX_PERFORMANCE_FEE = 0.5e18; // 50%
 uint256 constant MAX_MANAGEMENT_FEE = 0.05e18 / uint256(365 days); // 5%
 uint256 constant MAX_FORCE_DEALLOCATE_PENALTY = 0.02e18; // 2%

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 library ErrorsLib {
+    error Abdicated();
     error AbsoluteCapExceeded();
     error AbsoluteCapNotDecreasing();
     error AbsoluteCapNotIncreasing();
@@ -28,6 +29,7 @@ library ErrorsLib {
     error RelativeCapExceeded();
     error RelativeCapNotDecreasing();
     error RelativeCapNotIncreasing();
+    error TimelockDurationTooHigh();
     error TimelockIsAutomatic();
     error TimelockNotDecreasing();
     error TimelockNotExpired();

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -55,6 +55,7 @@ library EventsLib {
     event SetSendAssetsGate(address indexed newSendAssetsGate);
     event AddAdapter(address indexed account);
     event RemoveAdapter(address indexed account);
+    event AbdicateSubmit(bytes4 indexed selector);
     event DecreaseTimelock(bytes4 indexed selector, uint256 newDuration);
     event IncreaseTimelock(bytes4 indexed selector, uint256 newDuration);
     event SetLiquidityAdapterAndData(


### PR DESCRIPTION
* the timelock to decrease a timelock for a selector is the timelock of that selector
* increaseTimelock is timelocked
* 1 year global cap on timelocks for sanity
* keep abdicate