### PR TITLE
Fetch submodules via https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,10 @@
 	url = https://github.com/openzeppelin/openzeppelin-contracts
 [submodule "lib/morpho-blue"]
 	path = lib/morpho-blue
-	url = git@github.com:morpho-org/morpho-blue.git
+	url = https://github.com/morpho-org/morpho-blue
 [submodule "lib/metamorpho"]
 	path = lib/metamorpho
-	url = git@github.com:morpho-org/metamorpho.git
+	url = https://github.com/morpho-org/metamorpho
 [submodule "lib/metamorpho-v1.1"]
 	path = lib/metamorpho-v1.1
-	url = git@github.com:morpho-org/metamorpho-v1.1.git
+	url = https://github.com/morpho-org/metamorpho-v1.1


### PR DESCRIPTION
Fixes:
- #788. 

Indeed I checked that without a key, before this PR, it failed to fetch submodules. Reproduce with those steps:
- clone a fresh repo
- `GIT_SSH_COMMAND='ssh -o IdentitiesOnly=yes -o IdentityFile=/dev/null' git submodule update --init --recursive`
- this will give errors like `Failed to clone 'lib/metamorpho-v1.1'. Retry scheduled`