### PR TITLE
Re-order errors alphabetically

### DIFF
--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -9,6 +9,7 @@ library ErrorsLib {
     error AbsoluteCapNotIncreasing();
     error ApproveReturnedFalse();
     error ApproveReverted();
+    error AutomaticallyTimelocked();
     error CannotReceiveShares();
     error CannotReceiveAssets();
     error CannotSendShares();
@@ -30,7 +31,6 @@ library ErrorsLib {
     error RelativeCapExceeded();
     error RelativeCapNotDecreasing();
     error RelativeCapNotIncreasing();
-    error AutomaticallyTimelocked();
     error TimelockNotDecreasing();
     error TimelockNotExpired();
     error TimelockNotIncreasing();


### PR DESCRIPTION
Was a bit annoying to check the consistency of the new adapter and the vault errors because of this one. From what I tested, it does not change the bytecode of vaults