### PR TITLE
[Certora] initialization of contracts

### DIFF
--- a/certora/confs/AllocationMorphoMarketV1AdapterV2.conf
+++ b/certora/confs/AllocationMorphoMarketV1AdapterV2.conf
@@ -24,6 +24,7 @@
   "loop_iter": "4",
   "exclude_rule": "allocationIsInt256",
   "prover_args": [
+    "-allContractsZeroedForInvariantBaseCase true",
     "-destructiveOptimizations twostage",
     "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],


### PR DESCRIPTION
Fixes:
- #878 

The new release is now more conservative and doesn't assume that all contracts are 0 at the start, only the currentContract.  Unfortunately, this makes the CI fail (see corresponding issue above) because, in the run:
- the currentContract is the vault v2, not the adapter
- which means that it can choose an arbitrary value for the starting internal accounting of shares. In particular it can choose a number of accounted shares that is greater than the number of shares it actually holds

2 fixes are possible:
- separate this invariant in another file, where the current contract is the adapter.
- just use the previous settings of the prover, which the provided flag. This is the approach of this PR, chosen for the simplicity. [Here](https://prover.certora.com/output/66603/21e9a49251184ea2aed02c948fde4e97) is a passing run