### PR TITLE
[midnigth adapter] max active maturities + clean inactive maturities

### DIFF
--- a/src/adapters/MidnightAdapter.sol
+++ b/src/adapters/MidnightAdapter.sol
@@ -44,6 +44,7 @@ contract MidnightAdapter is IMidnightAdapter {
     uint48 public lastUpdate;
     uint48 public firstMaturity;
     uint128 public currentGrowth;
+    uint256 public activableMaturities = 50;
     mapping(uint256 timestamp => MaturityData) public _maturities;
     mapping(bytes32 obligationId => uint256) public netCredit;
     /* CONSTRUCTOR */
@@ -287,6 +288,8 @@ contract MidnightAdapter is IMidnightAdapter {
             removeUnits(obligationId, obligation.maturity, loss);
         }
 
+        if (maturityData.netCredit == 0 && buyNetCreditIncrease > 0) activableMaturities--;
+
         IVaultV2(parentVault).allocate(address(this), abi.encode(ids(obligation), change), paidAssets);
 
         if (timeToMaturity > 0) {
@@ -318,11 +321,15 @@ contract MidnightAdapter is IMidnightAdapter {
             }
 
             if (nextMaturity > obligation.maturity) {
+                maturityData.prevMaturity = prevMaturity;
                 maturityData.nextMaturity = nextMaturity;
                 if (prevMaturity == 0) {
                     firstMaturity = obligation.maturity.toUint48();
                 } else {
                     _maturities[prevMaturity].nextMaturity = obligation.maturity.toUint48();
+                }
+                if (nextMaturity < type(uint48).max) {
+                    _maturities[nextMaturity].prevMaturity = obligation.maturity.toUint48();
                 }
             }
         }
@@ -384,6 +391,23 @@ contract MidnightAdapter is IMidnightAdapter {
         }
         maturityData.netCredit -= removedUnits.toUint128();
         netCredit[obligationId] -= removedUnits.toUint128();
+
+        if (removedUnits > 0 && maturityData.netCredit == 0) {
+            activableMaturities++;
+            if (maturity > block.timestamp) {
+                uint48 prevMaturity = maturityData.prevMaturity;
+                uint48 nextMaturity = maturityData.nextMaturity;
+                if (maturity == firstMaturity) {
+                    firstMaturity = nextMaturity;
+                } else {
+                    _maturities[prevMaturity].nextMaturity = nextMaturity;
+                }
+                if (nextMaturity < type(uint48).max) {
+                    _maturities[nextMaturity].prevMaturity = prevMaturity;
+                }
+                maturityData.nextMaturity = 0;
+            }
+        }
     }
 
     function durationIndex(uint256 maturity) internal view returns (uint256 index) {

--- a/src/adapters/MidnightAdapter.sol
+++ b/src/adapters/MidnightAdapter.sol
@@ -305,6 +305,7 @@ contract MidnightAdapter is IMidnightAdapter {
             if (prevMaturity == 0) {
                 nextMaturity = firstMaturity;
             } else {
+                require(prevMaturity >= block.timestamp, IncorrectHint());
                 nextMaturity = _maturities[prevMaturity].nextMaturity;
                 require(nextMaturity > 0, IncorrectHint());
             }

--- a/src/adapters/MidnightAdapter.sol
+++ b/src/adapters/MidnightAdapter.sol
@@ -310,9 +310,8 @@ contract MidnightAdapter is IMidnightAdapter {
             if (prevMaturity == 0) {
                 nextMaturity = firstMaturity;
             } else {
-                require(prevMaturity >= block.timestamp, IncorrectHint());
+                require(prevMaturity >= firstMaturity && _maturities[prevMaturity].netCredit > 0, IncorrectHint());
                 nextMaturity = _maturities[prevMaturity].nextMaturity;
-                require(nextMaturity > 0, IncorrectHint());
             }
 
             while (nextMaturity < obligation.maturity) {
@@ -405,7 +404,6 @@ contract MidnightAdapter is IMidnightAdapter {
                 if (nextMaturity < type(uint48).max) {
                     _maturities[nextMaturity].prevMaturity = prevMaturity;
                 }
-                maturityData.nextMaturity = 0;
             }
         }
     }

--- a/src/adapters/interfaces/IMidnightAdapter.sol
+++ b/src/adapters/interfaces/IMidnightAdapter.sol
@@ -8,7 +8,6 @@ import {ICallbacks} from "lib/midnight/src/interfaces/ICallbacks.sol";
 import {IRatifier} from "lib/midnight/src/interfaces/IRatifier.sol";
 
 // Chain of maturities, each can represent multiple obligations.
-// prevMaturity is 0 if no previous maturity.
 // nextMaturity is type(uint48).max if no next maturity.
 struct MaturityData {
     uint128 netCredit;
@@ -43,11 +42,9 @@ interface IMidnightAdapter is IAdapter, ICallbacks, IRatifier {
     error NotMidnight();
     error NotSelf();
     error SelfAllocationOnly();
-    error TooManyActiveMaturities();
 
     /* FUNCTIONS */
 
-    function MAX_ACTIVE_MATURITIES() external view returns (uint256);
     function asset() external view returns (address);
     function _totalAssets() external view returns (uint256);
     function lastUpdate() external view returns (uint48);

--- a/src/adapters/interfaces/IMidnightAdapter.sol
+++ b/src/adapters/interfaces/IMidnightAdapter.sol
@@ -8,10 +8,12 @@ import {ICallbacks} from "lib/midnight/src/interfaces/ICallbacks.sol";
 import {IRatifier} from "lib/midnight/src/interfaces/IRatifier.sol";
 
 // Chain of maturities, each can represent multiple obligations.
-// nextMaturity is type(uint48).max if no next maturity
+// prevMaturity is 0 if no previous maturity.
+// nextMaturity is type(uint48).max if no next maturity.
 struct MaturityData {
     uint128 netCredit;
     uint128 growth;
+    uint48 prevMaturity;
     uint48 nextMaturity;
     uint8 durationIndex;
 }
@@ -41,14 +43,17 @@ interface IMidnightAdapter is IAdapter, ICallbacks, IRatifier {
     error NotMidnight();
     error NotSelf();
     error SelfAllocationOnly();
+    error TooManyActiveMaturities();
 
     /* FUNCTIONS */
 
+    function MAX_ACTIVE_MATURITIES() external view returns (uint256);
     function asset() external view returns (address);
     function _totalAssets() external view returns (uint256);
     function lastUpdate() external view returns (uint48);
     function firstMaturity() external view returns (uint48);
     function currentGrowth() external view returns (uint128);
+    function activeMaturities() external view returns (uint256);
     function midnight() external view returns (address);
     function adapterId() external view returns (bytes32);
     function packedDurations() external view returns (bytes32);


### PR DESCRIPTION
Prevent DOS by adding so many maturities that accrual goes out of gas.

With this PR an allocator could prevent new buys by activating the max number of maturities.