### PR TITLE
Add .gitattributes for Certora GitHub syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.spec linguist-language=Solidity
+*.conf linguist-detectable
+*.conf linguist-language=JSON5


### PR DESCRIPTION
Adds `.gitattributes` rules so GitHub Linguist correctly detects and syntax-highlights Certora `.spec` files as Solidity and `.conf` files as JSON5 as explained in https://docs.certora.com/en/latest/docs/user-guide/github_highlighting.html

**Current (no `.gitattributes`)**: GitHub renders the Certora `.spec`/`.conf` files with poor or generic highlighting, which makes them harder to read.  
  - Spec: [certora/specs/TokensMorphoMarketV1AdapterV2.spec](https://github.com/morpho-org/vault-v2/blob/f2975ca58c29b7a35d24b3ce4efb5216ec1e3b66/certora/specs/TokensMorphoMarketV1AdapterV2.spec)  
  - Conf: [certora/confs/TokensMorphoMarketV1AdapterV2.conf](https://github.com/morpho-org/vault-v2/blob/f2975ca58c29b7a35d24b3ce4efb5216ec1e3b66/certora/confs/TokensMorphoMarketV1AdapterV2.conf)

**With this change**: GitHub highlights `.spec` as **Solidity** and `.conf` as **JSON5**, improving readability.  
  - Spec: [certora/specs/TokensMorphoMarketV1AdapterV2.spec](https://github.com/patitonar/vault-v2/blob/certora_syntax_highlighting/certora/specs/TokensMorphoMarketV1AdapterV2.spec)  
  - Conf: [certora/confs/TokensMorphoMarketV1AdapterV2.conf](https://github.com/patitonar/vault-v2/blob/certora_syntax_highlighting/certora/confs/TokensMorphoMarketV1AdapterV2.conf)

